### PR TITLE
Fix: conversion from int to string yields a string of one rune, not a string of digits

### DIFF
--- a/datatable.go
+++ b/datatable.go
@@ -1405,7 +1405,7 @@ func (dt *DataTable) getMaxColumnLength() int {
 func generateColumnIndex(index int) string {
 	name := ""
 	for index >= 0 {
-		name = string('A'+(index%26)) + name
+		name = fmt.Sprintf("%c%s", 'A'+(index%26), name)
 		index = index/26 - 1
 	}
 	return name


### PR DESCRIPTION
```sh
go test --run ./...
# github.com/HazelnutParadise/insyra
# [github.com/HazelnutParadise/insyra]
./datatable.go:1408:10: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL    github.com/HazelnutParadise/insyra [build failed]
```