### PR TITLE
Fix ClearStrings when the length is smaller than runtime.NumCPU()

### DIFF
--- a/datalist.go
+++ b/datalist.go
@@ -562,7 +562,7 @@ func (dl *DataList) ClearStrings() *DataList {
 	}
 
 	// 獲取可用的 CPU 核心數量
-	numGoroutines := runtime.NumCPU()
+	numGoroutines := min(runtime.NumCPU(), length)
 
 	// 決定每個線程處理的數據量
 	chunkSize := length / numGoroutines

--- a/datalist_test.go
+++ b/datalist_test.go
@@ -1,6 +1,7 @@
 package insyra
 
 import (
+	"fmt"
 	"reflect"
 	"slices"
 	"sort"
@@ -231,7 +232,43 @@ func TestDataListClear(t *testing.T) {
 }
 
 func TestDataListClearStrings(t *testing.T) {
-	// TODO
+	// for small test
+	dl := NewDataList("a", "b", "c", 0, 1, 2)
+
+	dl.ClearStrings()
+	if dl.Len() != 3 {
+		t.Errorf("Expected length 3, got %d", dl.Len())
+	}
+
+	var visited [3]bool
+	for i := 0; i < 3; i++ {
+		visited[dl.Get(i).(int)] = true
+	}
+	for i := 0; i < 3; i++ {
+		if !visited[i] {
+			t.Errorf("Expected %d in dataList", i)
+		}
+	}
+
+	// for large test
+	const n = 5000
+	dl = NewDataList()
+	for i := 0; i < n; i++ {
+		dl.Append(fmt.Sprintf("string-%d", i))
+	}
+	for i := 0; i < n; i++ {
+		dl.Append(i)
+	}
+	dl.ClearStrings()
+	var visited2 [n]bool
+	for i := 0; i < n; i++ {
+		visited2[i] = true
+	}
+	for i := 0; i < n; i++ {
+		if !visited2[i] {
+			t.Errorf("Expected %d in dataList", i)
+		}
+	}
 }
 
 func TestDataListClearNumbers(t *testing.T) {


### PR DESCRIPTION
When the datalist is smaller than numCPU(), the for loop iterates beyond the actual length of the datalist.