### PR TITLE
feat(ccl): expand stdlib with math, string, type-conv, date, and stat aggregate functions

### DIFF
--- a/Docs/CCL.md
+++ b/Docs/CCL.md
@@ -585,6 +585,96 @@ Example:
 // Returns 'A' if A > 90, 'B' if A > 80, 'C' if A > 70, otherwise returns 'F'
 ```
 
+### Math Functions
+
+Standard scalar math functions. All accept any value coercible to a number; passing a non-coercible value returns a typed error.
+
+| Function | Description | Example |
+| --- | --- | --- |
+| `ABS(x)` | Absolute value | `ABS(-3.5)` → `3.5` |
+| `ROUND(x, n?)` | Round to `n` decimal places (default `0`) | `ROUND(3.14159, 2)` → `3.14` |
+| `FLOOR(x)` | Largest integer ≤ x | `FLOOR(3.7)` → `3` |
+| `CEIL(x)` | Smallest integer ≥ x | `CEIL(3.2)` → `4` |
+| `TRUNC(x)` | Truncate fractional part | `TRUNC(-3.9)` → `-3` |
+| `MOD(a, b)` | Floating-point remainder of `a / b` | `MOD(10, 3)` → `1` |
+| `POW(base, exp)` | Power | `POW(2, 10)` → `1024` |
+| `SQRT(x)` | Square root (errors on negatives) | `SQRT(16)` → `4` |
+| `LN(x)` | Natural log | `LN(E)` → `1` |
+| `LOG(x, base?)` | `LOG(x)` defaults to base 10; otherwise log base `base` | `LOG(8, 2)` → `3` |
+| `LOG10(x)` | Base-10 log | `LOG10(100)` → `2` |
+| `EXP(x)` | e^x | `EXP(0)` → `1` |
+| `SIGN(x)` | -1, 0, or 1 | `SIGN(-7)` → `-1` |
+
+```go
+dt.AddColUsingCCL("tax", "ROUND(['price'] * 0.0825, 2)")
+dt.AddColUsingCCL("delta", "ABS(['actual'] - ['target'])")
+```
+
+### String Functions
+
+All string functions are rune-aware (Unicode safe). `nil` is treated as the empty string. `LEN` returns rune count, `LEFT`/`RIGHT`/`MID`/`SUBSTR` slice by rune.
+
+| Function | Description |
+| --- | --- |
+| `LEN(s)` | Number of Unicode characters |
+| `UPPER(s)` / `LOWER(s)` | Case conversion |
+| `TRIM(s)` / `LTRIM(s)` / `RTRIM(s)` | Strip ASCII whitespace from both / left / right |
+| `LEFT(s, n)` | First `n` characters |
+| `RIGHT(s, n)` | Last `n` characters |
+| `MID(s, start, length)` / `SUBSTR(...)` | Substring (1-based start, like Excel) |
+| `REPLACE(s, old, new)` | Replace all occurrences of `old` with `new` |
+| `FIND(needle, haystack)` | 1-based position of `needle`; `0` if not found |
+| `CONTAINS(s, sub)` / `STARTSWITH(s, p)` / `ENDSWITH(s, p)` | Boolean checks |
+| `REGEX_MATCH(s, pattern)` | Go regexp match |
+| `REPEAT(s, n)` | Repeat `s` `n` times |
+
+```go
+// Email cleanup pipeline
+dt.ExecuteCCL(`
+    ['email'] = LOWER(TRIM(['email']))
+    NEW('domain') = MID(['email'], FIND('@', ['email']) + 1, LEN(['email']))
+    NEW('is_gift') = CONTAINS(LOWER(['description']), 'gift')
+`)
+```
+
+### Type-Conversion and Null Helpers
+
+| Function | Description |
+| --- | --- |
+| `TONUM(x)` / `VALUE(x)` | Coerce to `float64`; returns `nil` if conversion fails |
+| `TOSTR(x, fmt?)` / `TEXT(x, fmt?)` | Convert to string. With a second argument, formats using a Go `fmt` verb (e.g. `"%.2f"`) |
+| `TOBOOL(x)` | Coerce to bool; `nil`/non-coercible → `nil` |
+| `COALESCE(a, b, ...)` | First non-`nil`, non-`NaN` argument |
+| `IFNULL(x, fallback)` | `fallback` when `x` is `nil`; otherwise `x` |
+
+`IFNULL` differs from the existing `IFNA`: `IFNA` only triggers on float `NaN` or the string `"#N/A"`, while `IFNULL` matches actual `nil` values.
+
+```go
+dt.AddColUsingCCL("price_num", "COALESCE(TONUM(['price_str']), 0)")
+dt.AddColUsingCCL("price_fmt", "TOSTR(['price'], '$%.2f')")
+```
+
+### Date Component & Arithmetic Functions
+
+These complement the existing `DAY`/`HOUR`/`MINUTE`/`SECOND` duration helpers and operate on `time.Time` values (or strings parseable by Insyra's date parser).
+
+| Function | Description |
+| --- | --- |
+| `YEAR(d)` | Year as number |
+| `MONTH(d)` | Month 1–12 |
+| `DAYOFMONTH(d)` | Day 1–31 |
+| `WEEKDAY(d)` | 0 (Sunday) – 6 (Saturday) |
+| `DATEDIFF(d1, d2, unit)` | `d1 - d2` in `'day'` / `'hour'` / `'minute'` / `'second'` |
+| `DATEADD(d, n, unit)` | Shift `d` by `n` units. Supports `day`/`hour`/`minute`/`second`/`month`/`year` |
+| `FORMAT_DATE(d, layout)` | Format using a Go reference layout (e.g. `"2006-01-02"`) |
+
+```go
+dt.AddColUsingCCL("order_year", "YEAR(['order_date'])")
+dt.AddColUsingCCL("days_open", "DATEDIFF(['closed_at'], ['opened_at'], 'day')")
+dt.AddColUsingCCL("renew_at", "DATEADD(['signed_at'], 1, 'year')")
+dt.AddColUsingCCL("order_iso", "FORMAT_DATE(['order_date'], '2006-01-02')")
+```
+
 ## Aggregate Functions
 
 Aggregate functions perform calculations on a set of values (a column, a row, or an expression) and return a single value. This value is then "broadcasted" to all rows in the resulting column (unless in row-wise mode).
@@ -663,6 +753,34 @@ Calculates the minimum value among all numeric values in the input.
 "MIN(A, B)"          // Minimum value in columns A and B
 "MIN(@.#)"           // Minimum value in the current row
 "MIN(@)"             // Minimum value in the entire tableW
+```
+
+### MEDIAN
+
+Calculates the median (50th percentile) of all numeric values in the input. For even-count inputs returns the mean of the two middle values.
+
+```
+"MEDIAN(A)"          // Median of column A
+"MEDIAN(@.#)"        // Median of the current row
+```
+
+### STDEV / STDEVP
+
+Sample standard deviation (`STDEV`, divides by `n-1`) and population standard deviation (`STDEVP`, divides by `n`). `STDEV` requires at least 2 numeric values; `STDEVP` requires at least 1.
+
+```
+"STDEV(A)"
+"STDEVP(@)"
+"(['price'] - AVG(['price'])) / STDEV(['price'])"   // z-score
+```
+
+### VAR / VARP
+
+Sample variance (`VAR`, divides by `n-1`) and population variance (`VARP`, divides by `n`). `VAR` requires at least 2 numeric values; `VARP` requires at least 1.
+
+```
+"VAR(A)"
+"VARP(@.#)"
 ```
 
 ## Row-wise Aggregation

--- a/datatable_ccl_stdlib_test.go
+++ b/datatable_ccl_stdlib_test.go
@@ -1,0 +1,177 @@
+package insyra
+
+import (
+	"math"
+	"testing"
+)
+
+// TestDataTable_CCL_StdlibIntegration exercises a representative slice of the
+// expanded CCL standard library through the real DataTable code path
+// (AddColUsingCCL + ExecuteCCL). This is a smoke test for issue #154 — it
+// confirms math, string, type-conversion, and statistical-aggregate
+// functions are reachable from the public API, not just registered.
+func TestDataTable_CCL_StdlibIntegration(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(-3, 4, -5, 0).SetName("X"),
+		NewDataList("Foo", " Bar ", "BAZ", "qux").SetName("Name"),
+		NewDataList(1.0, 2.0, 3.0, 4.0).SetName("Vals"),
+	)
+
+	// Math: ABS, ROUND, SQRT, SIGN
+	dt.AddColUsingCCL("AbsX", "ABS(A)")
+	dt.AddColUsingCCL("RoundedHalf", "ROUND(C / 3, 2)")
+	dt.AddColUsingCCL("SqrtVals", "SQRT(C)")
+	dt.AddColUsingCCL("SignX", "SIGN(A)")
+
+	// String: TRIM + UPPER chained, LEN, CONTAINS, LEFT
+	dt.AddColUsingCCL("CleanName", "UPPER(TRIM(B))")
+	dt.AddColUsingCCL("NameLen", "LEN(B)")
+	dt.AddColUsingCCL("HasA", "CONTAINS(LOWER(B), 'a')")
+	dt.AddColUsingCCL("Prefix", "LEFT(B, 2)")
+
+	// Type conversion / null handling
+	dt.AddColUsingCCL("XStr", "TOSTR(A)")
+	dt.AddColUsingCCL("XOrZero", "COALESCE(A, 0)")
+
+	// Aggregates: STDEV / VAR / MEDIAN broadcast across rows
+	dt.AddColUsingCCL("ValsStdev", "STDEV(C)")
+	dt.AddColUsingCCL("ValsMedian", "MEDIAN(C)")
+
+	if err := dt.Err(); err != nil {
+		t.Fatalf("unexpected DataTable error: %s", err.Message)
+	}
+
+	getF := func(name string) []float64 {
+		t.Helper()
+		col := dt.GetColByName(name)
+		if col == nil {
+			t.Fatalf("column %q not found", name)
+		}
+		out := make([]float64, 0, len(col.Data()))
+		for _, v := range col.Data() {
+			f, ok := v.(float64)
+			if !ok {
+				t.Fatalf("column %q: expected float64 row, got %T (%v)", name, v, v)
+			}
+			out = append(out, f)
+		}
+		return out
+	}
+	getS := func(name string) []string {
+		t.Helper()
+		col := dt.GetColByName(name)
+		if col == nil {
+			t.Fatalf("column %q not found", name)
+		}
+		out := make([]string, 0, len(col.Data()))
+		for _, v := range col.Data() {
+			s, ok := v.(string)
+			if !ok {
+				t.Fatalf("column %q: expected string row, got %T (%v)", name, v, v)
+			}
+			out = append(out, s)
+		}
+		return out
+	}
+
+	checkF := func(name string, want []float64) {
+		t.Helper()
+		got := getF(name)
+		if len(got) != len(want) {
+			t.Fatalf("%s: length mismatch got=%d want=%d", name, len(got), len(want))
+		}
+		for i := range got {
+			if math.Abs(got[i]-want[i]) > 1e-9 {
+				t.Errorf("%s row %d: got %v want %v", name, i, got[i], want[i])
+			}
+		}
+	}
+	checkS := func(name string, want []string) {
+		t.Helper()
+		got := getS(name)
+		if len(got) != len(want) {
+			t.Fatalf("%s: length mismatch got=%d want=%d", name, len(got), len(want))
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("%s row %d: got %q want %q", name, i, got[i], want[i])
+			}
+		}
+	}
+
+	checkF("AbsX", []float64{3, 4, 5, 0})
+	checkF("SqrtVals", []float64{1, math.Sqrt(2), math.Sqrt(3), 2})
+	checkF("SignX", []float64{-1, 1, -1, 0})
+	checkS("CleanName", []string{"FOO", "BAR", "BAZ", "QUX"})
+	checkF("NameLen", []float64{3, 5, 3, 3})
+
+	// HasA: "foo" no, " bar " yes, "baz" yes, "qux" no
+	hasA := dt.GetColByName("HasA").Data()
+	wantHas := []bool{false, true, true, false}
+	for i, v := range hasA {
+		b, ok := v.(bool)
+		if !ok || b != wantHas[i] {
+			t.Errorf("HasA row %d: got %v want %v", i, v, wantHas[i])
+		}
+	}
+
+	checkS("Prefix", []string{"Fo", " B", "BA", "qu"})
+
+	// Aggregate broadcast: STDEV/MEDIAN of {1,2,3,4} across 4 rows.
+	wantStdev := math.Sqrt(((1-2.5)*(1-2.5) + (2-2.5)*(2-2.5) + (3-2.5)*(3-2.5) + (4-2.5)*(4-2.5)) / 3.0)
+	for i, f := range getF("ValsStdev") {
+		if math.Abs(f-wantStdev) > 1e-9 {
+			t.Errorf("ValsStdev row %d: got %v want %v", i, f, wantStdev)
+		}
+	}
+	for i, f := range getF("ValsMedian") {
+		if f != 2.5 {
+			t.Errorf("ValsMedian row %d: got %v want 2.5", i, f)
+		}
+	}
+}
+
+// TestDataTable_ExecuteCCL_StdlibPipeline runs a multi-statement pipeline
+// that mixes new string and type helpers with assignment + NEW(), which is
+// the path most likely to expose wiring bugs in Statement Mode.
+func TestDataTable_ExecuteCCL_StdlibPipeline(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(" alice@Example.com ", "BOB@TEST.org", "carol@demo.io").SetName("Email"),
+		NewDataList("19", "30", "not-a-number").SetName("AgeStr"),
+	)
+
+	dt.ExecuteCCL(`
+		['Email'] = LOWER(TRIM(['Email']))
+		NEW('Domain') = MID(['Email'], FIND('@', ['Email']) + 1, LEN(['Email']))
+		NEW('AgeNum') = COALESCE(TONUM(['AgeStr']), 0)
+	`)
+
+	if err := dt.Err(); err != nil {
+		t.Fatalf("unexpected DataTable error: %s", err.Message)
+	}
+
+	emails := dt.GetColByName("Email").Data()
+	wantEmails := []string{"alice@example.com", "bob@test.org", "carol@demo.io"}
+	for i, v := range emails {
+		if v != wantEmails[i] {
+			t.Errorf("Email row %d: got %v want %v", i, v, wantEmails[i])
+		}
+	}
+
+	domains := dt.GetColByName("Domain").Data()
+	wantDomains := []string{"example.com", "test.org", "demo.io"}
+	for i, v := range domains {
+		if v != wantDomains[i] {
+			t.Errorf("Domain row %d: got %v want %v", i, v, wantDomains[i])
+		}
+	}
+
+	ageNums := dt.GetColByName("AgeNum").Data()
+	wantAges := []float64{19, 30, 0}
+	for i, v := range ageNums {
+		f, ok := v.(float64)
+		if !ok || math.Abs(f-wantAges[i]) > 1e-9 {
+			t.Errorf("AgeNum row %d: got %v want %v", i, v, wantAges[i])
+		}
+	}
+}

--- a/internal/ccl/stdlib.go
+++ b/internal/ccl/stdlib.go
@@ -11,9 +11,28 @@ import (
 )
 
 // RegisterStandardFunctions registers the standard library of CCL functions.
-// This includes logical functions (IF, AND, OR), string functions (CONCAT),
-// and aggregate functions (SUM, AVG, COUNT, MAX, MIN).
+// Categories:
+//   - Logical: IF, AND, OR, CASE
+//   - Null/NaN: ISNA, IFNA
+//   - String concat / duration helpers (this file)
+//   - Math (stdlib_math.go): ABS, ROUND, FLOOR, CEIL, TRUNC, MOD, POW,
+//     SQRT, LN, LOG, LOG10, EXP, SIGN
+//   - String (stdlib_string.go): LEN, UPPER, LOWER, TRIM/L/RTRIM,
+//     LEFT, RIGHT, MID/SUBSTR, REPLACE, FIND, CONTAINS, STARTSWITH,
+//     ENDSWITH, REGEX_MATCH, REPEAT
+//   - Type conversion (stdlib_typeconv.go): TONUM/VALUE, TOSTR/TEXT,
+//     TOBOOL, COALESCE, IFNULL
+//   - Date components (stdlib_datetime.go): YEAR, MONTH, DAYOFMONTH,
+//     WEEKDAY, DATEDIFF, DATEADD, FORMAT_DATE
+//   - Aggregates: SUM, AVG, COUNT, MAX, MIN (this file) and
+//     MEDIAN, STDEV/STDEVP, VAR/VARP (stdlib_aggregates.go)
 func RegisterStandardFunctions() {
+	registerMathFunctions()
+	registerStringFunctions()
+	registerTypeConversionFunctions()
+	registerDateTimeFunctions()
+	registerAggregateStatFunctions()
+
 	// Logical Functions
 	registerFunction("IF", func(args ...any) (any, error) {
 		if len(args) != 3 {

--- a/internal/ccl/stdlib_aggregates.go
+++ b/internal/ccl/stdlib_aggregates.go
@@ -1,0 +1,104 @@
+package ccl
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+// collectFloats walks the aggregate input the same way forEachValue does and
+// collects all values that can be coerced to float64.
+func collectFloats(args [][]any) []float64 {
+	var out []float64
+	forEachValue(args, func(val any) {
+		if f, ok := toFloat64(val); ok {
+			out = append(out, f)
+		}
+	})
+	return out
+}
+
+// registerAggregateStatFunctions registers MEDIAN / STDEV / STDEVP / VAR / VARP.
+// Sample variants (STDEV, VAR) divide by n-1; population variants (STDEVP,
+// VARP) divide by n. All ignore nil values, matching SUM/AVG/COUNT semantics.
+func registerAggregateStatFunctions() {
+	registerAggregateFunction("MEDIAN", func(args ...[]any) (any, error) {
+		vals := collectFloats(args)
+		if len(vals) == 0 {
+			return nil, nil
+		}
+		sort.Float64s(vals)
+		n := len(vals)
+		if n%2 == 1 {
+			return vals[n/2], nil
+		}
+		return (vals[n/2-1] + vals[n/2]) / 2.0, nil
+	})
+
+	variance := func(vals []float64, sample bool) (float64, bool) {
+		n := len(vals)
+		if n < 1 {
+			return 0, false
+		}
+		if sample && n < 2 {
+			return 0, false
+		}
+		var sum float64
+		for _, v := range vals {
+			sum += v
+		}
+		mean := sum / float64(n)
+		var ss float64
+		for _, v := range vals {
+			d := v - mean
+			ss += d * d
+		}
+		denom := float64(n)
+		if sample {
+			denom = float64(n - 1)
+		}
+		return ss / denom, true
+	}
+
+	registerAggregateFunction("VAR", func(args ...[]any) (any, error) {
+		vals := collectFloats(args)
+		v, ok := variance(vals, true)
+		if !ok {
+			if len(vals) < 2 {
+				return nil, fmt.Errorf("VAR requires at least 2 numeric values")
+			}
+			return nil, nil
+		}
+		return v, nil
+	})
+
+	registerAggregateFunction("VARP", func(args ...[]any) (any, error) {
+		vals := collectFloats(args)
+		v, ok := variance(vals, false)
+		if !ok {
+			return nil, fmt.Errorf("VARP requires at least 1 numeric value")
+		}
+		return v, nil
+	})
+
+	registerAggregateFunction("STDEV", func(args ...[]any) (any, error) {
+		vals := collectFloats(args)
+		v, ok := variance(vals, true)
+		if !ok {
+			if len(vals) < 2 {
+				return nil, fmt.Errorf("STDEV requires at least 2 numeric values")
+			}
+			return nil, nil
+		}
+		return math.Sqrt(v), nil
+	})
+
+	registerAggregateFunction("STDEVP", func(args ...[]any) (any, error) {
+		vals := collectFloats(args)
+		v, ok := variance(vals, false)
+		if !ok {
+			return nil, fmt.Errorf("STDEVP requires at least 1 numeric value")
+		}
+		return math.Sqrt(v), nil
+	})
+}

--- a/internal/ccl/stdlib_datetime.go
+++ b/internal/ccl/stdlib_datetime.go
@@ -1,0 +1,160 @@
+package ccl
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/HazelnutParadise/insyra/internal/utils"
+)
+
+// toTime coerces a value to time.Time. Accepts time.Time directly or a
+// string parseable by utils.TryParseTime.
+func toTime(val any) (time.Time, bool) {
+	switch x := val.(type) {
+	case time.Time:
+		return x, true
+	case string:
+		if t, ok := utils.TryParseTime(x); ok {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// registerDateTimeFunctions registers date-component extraction and arithmetic
+// helpers. These complement the existing DAY/HOUR/MINUTE/SECOND duration
+// functions in stdlib.go, which operate on time.Duration values.
+func registerDateTimeFunctions() {
+	registerFunction("YEAR", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("YEAR requires 1 argument")
+		}
+		t, ok := toTime(args[0])
+		if !ok {
+			return nil, fmt.Errorf("YEAR: cannot convert %T to date", args[0])
+		}
+		return float64(t.Year()), nil
+	})
+
+	registerFunction("MONTH", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("MONTH requires 1 argument")
+		}
+		t, ok := toTime(args[0])
+		if !ok {
+			return nil, fmt.Errorf("MONTH: cannot convert %T to date", args[0])
+		}
+		return float64(t.Month()), nil
+	})
+
+	registerFunction("DAYOFMONTH", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("DAYOFMONTH requires 1 argument")
+		}
+		t, ok := toTime(args[0])
+		if !ok {
+			return nil, fmt.Errorf("DAYOFMONTH: cannot convert %T to date", args[0])
+		}
+		return float64(t.Day()), nil
+	})
+
+	// WEEKDAY returns 0 (Sunday) through 6 (Saturday), matching time.Weekday.
+	registerFunction("WEEKDAY", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("WEEKDAY requires 1 argument")
+		}
+		t, ok := toTime(args[0])
+		if !ok {
+			return nil, fmt.Errorf("WEEKDAY: cannot convert %T to date", args[0])
+		}
+		return float64(t.Weekday()), nil
+	})
+
+	// DATEDIFF(d1, d2, unit) returns d1 - d2 expressed in the requested unit.
+	// Supported units (case-insensitive): "day"/"days", "hour"/"hours",
+	// "minute"/"minutes", "second"/"seconds".
+	registerFunction("DATEDIFF", func(args ...any) (any, error) {
+		if len(args) != 3 {
+			return nil, fmt.Errorf("DATEDIFF requires 3 arguments (d1, d2, unit)")
+		}
+		t1, ok := toTime(args[0])
+		if !ok {
+			return nil, fmt.Errorf("DATEDIFF: cannot convert first arg %T to date", args[0])
+		}
+		t2, ok := toTime(args[1])
+		if !ok {
+			return nil, fmt.Errorf("DATEDIFF: cannot convert second arg %T to date", args[1])
+		}
+		unit, ok := args[2].(string)
+		if !ok {
+			return nil, fmt.Errorf("DATEDIFF: unit must be a string, got %T", args[2])
+		}
+		diff := t1.Sub(t2)
+		switch strings.ToLower(unit) {
+		case "day", "days":
+			return diff.Hours() / 24.0, nil
+		case "hour", "hours":
+			return diff.Hours(), nil
+		case "minute", "minutes":
+			return diff.Minutes(), nil
+		case "second", "seconds":
+			return diff.Seconds(), nil
+		default:
+			return nil, fmt.Errorf("DATEDIFF: unknown unit %q (expected day/hour/minute/second)", unit)
+		}
+	})
+
+	// DATEADD(d, n, unit) returns d shifted by n units. Supports the same
+	// unit set as DATEDIFF plus "month"/"year" via time.AddDate.
+	registerFunction("DATEADD", func(args ...any) (any, error) {
+		if len(args) != 3 {
+			return nil, fmt.Errorf("DATEADD requires 3 arguments (d, n, unit)")
+		}
+		t, ok := toTime(args[0])
+		if !ok {
+			return nil, fmt.Errorf("DATEADD: cannot convert first arg %T to date", args[0])
+		}
+		n, ok := toFloat64(args[1])
+		if !ok {
+			return nil, fmt.Errorf("DATEADD: n must be a number, got %T", args[1])
+		}
+		unit, ok := args[2].(string)
+		if !ok {
+			return nil, fmt.Errorf("DATEADD: unit must be a string, got %T", args[2])
+		}
+		switch strings.ToLower(unit) {
+		case "day", "days":
+			return t.AddDate(0, 0, int(n)), nil
+		case "hour", "hours":
+			return t.Add(time.Duration(n * float64(time.Hour))), nil
+		case "minute", "minutes":
+			return t.Add(time.Duration(n * float64(time.Minute))), nil
+		case "second", "seconds":
+			return t.Add(time.Duration(n * float64(time.Second))), nil
+		case "month", "months":
+			return t.AddDate(0, int(n), 0), nil
+		case "year", "years":
+			return t.AddDate(int(n), 0, 0), nil
+		default:
+			return nil, fmt.Errorf("DATEADD: unknown unit %q", unit)
+		}
+	})
+
+	// FORMAT_DATE(d, layout) formats a date using a Go reference layout
+	// (e.g. "2006-01-02 15:04:05").
+	registerFunction("FORMAT_DATE", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("FORMAT_DATE requires 2 arguments (date, layout)")
+		}
+		t, ok := toTime(args[0])
+		if !ok {
+			return nil, fmt.Errorf("FORMAT_DATE: cannot convert %T to date", args[0])
+		}
+		layout, ok := args[1].(string)
+		if !ok {
+			return nil, fmt.Errorf("FORMAT_DATE: layout must be a string, got %T", args[1])
+		}
+		return t.Format(layout), nil
+	})
+}

--- a/internal/ccl/stdlib_extended_test.go
+++ b/internal/ccl/stdlib_extended_test.go
@@ -1,0 +1,390 @@
+package ccl
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Each test calls RegisterStandardFunctions to ensure the new helpers are
+// wired in alongside the existing ones. Registration is idempotent because
+// it overwrites map entries.
+func init() {
+	RegisterStandardFunctions()
+}
+
+// callFn invokes a registered scalar function by name and returns the result.
+// Wraps callFunction to reset funcCallDepth between tests.
+func callFn(t *testing.T, name string, args ...any) (any, error) {
+	t.Helper()
+	ResetFuncCallDepth()
+	return callFunction(name, args)
+}
+
+func callAgg(t *testing.T, name string, cols ...[]any) (any, error) {
+	t.Helper()
+	return callAggregateFunction(name, cols)
+}
+
+func wantFloat(t *testing.T, got any, want float64) {
+	t.Helper()
+	f, ok := got.(float64)
+	if !ok {
+		t.Fatalf("expected float64, got %T (%v)", got, got)
+	}
+	if math.IsNaN(want) {
+		if !math.IsNaN(f) {
+			t.Fatalf("expected NaN, got %v", f)
+		}
+		return
+	}
+	const eps = 1e-9
+	if math.Abs(f-want) > eps {
+		t.Fatalf("expected %v, got %v", want, f)
+	}
+}
+
+func wantString(t *testing.T, got any, want string) {
+	t.Helper()
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T (%v)", got, got)
+	}
+	if s != want {
+		t.Fatalf("expected %q, got %q", want, s)
+	}
+}
+
+func wantBool(t *testing.T, got any, want bool) {
+	t.Helper()
+	b, ok := got.(bool)
+	if !ok {
+		t.Fatalf("expected bool, got %T (%v)", got, got)
+	}
+	if b != want {
+		t.Fatalf("expected %v, got %v", want, b)
+	}
+}
+
+// ---------------------------------------------------------------- Math ----
+
+func TestMathFunctions(t *testing.T) {
+	cases := []struct {
+		name string
+		args []any
+		want float64
+	}{
+		{"ABS", []any{-3.5}, 3.5},
+		{"ABS", []any{2.0}, 2.0},
+		{"ROUND", []any{3.14159, 2.0}, 3.14},
+		{"ROUND", []any{2.5}, 3.0},
+		{"ROUND", []any{-1.6}, -2.0},
+		{"FLOOR", []any{3.7}, 3.0},
+		{"FLOOR", []any{-1.2}, -2.0},
+		{"CEIL", []any{3.2}, 4.0},
+		{"CEIL", []any{-1.8}, -1.0},
+		{"TRUNC", []any{3.9}, 3.0},
+		{"TRUNC", []any{-3.9}, -3.0},
+		{"MOD", []any{10.0, 3.0}, 1.0},
+		{"POW", []any{2.0, 10.0}, 1024.0},
+		{"SQRT", []any{16.0}, 4.0},
+		{"LN", []any{math.E}, 1.0},
+		{"LOG", []any{1000.0}, 3.0},        // base-10 default
+		{"LOG", []any{8.0, 2.0}, 3.0},      // explicit base
+		{"LOG10", []any{100.0}, 2.0},
+		{"EXP", []any{0.0}, 1.0},
+		{"SIGN", []any{-5.0}, -1.0},
+		{"SIGN", []any{0.0}, 0.0},
+		{"SIGN", []any{42.0}, 1.0},
+	}
+	for _, c := range cases {
+		got, err := callFn(t, c.name, c.args...)
+		if err != nil {
+			t.Fatalf("%s%v: unexpected error: %v", c.name, c.args, err)
+		}
+		wantFloat(t, got, c.want)
+	}
+}
+
+func TestMathErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []any
+		msg  string
+	}{
+		{"ABS", []any{}, "ABS requires"},
+		{"ABS", []any{"oops"}, "cannot convert"},
+		{"SQRT", []any{-1.0}, "negative"},
+		{"LN", []any{0.0}, "non-positive"},
+		{"LOG", []any{-1.0}, "non-positive"},
+		{"LOG", []any{10.0, 1.0}, "invalid base"},
+		{"MOD", []any{1.0, 0.0}, "division by zero"},
+	}
+	for _, c := range cases {
+		_, err := callFn(t, c.name, c.args...)
+		if err == nil {
+			t.Fatalf("%s%v: expected error containing %q, got nil", c.name, c.args, c.msg)
+		}
+		if !strings.Contains(err.Error(), c.msg) {
+			t.Fatalf("%s%v: expected error containing %q, got %v", c.name, c.args, c.msg, err)
+		}
+	}
+}
+
+// -------------------------------------------------------------- String ----
+
+func TestStringFunctions(t *testing.T) {
+	got, err := callFn(t, "LEN", "héllo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFloat(t, got, 5)
+
+	got, _ = callFn(t, "UPPER", "hello")
+	wantString(t, got, "HELLO")
+
+	got, _ = callFn(t, "LOWER", "WoRLD")
+	wantString(t, got, "world")
+
+	got, _ = callFn(t, "TRIM", "  hi  ")
+	wantString(t, got, "hi")
+
+	got, _ = callFn(t, "LTRIM", "  hi  ")
+	wantString(t, got, "hi  ")
+
+	got, _ = callFn(t, "RTRIM", "  hi  ")
+	wantString(t, got, "  hi")
+
+	got, _ = callFn(t, "LEFT", "abcdef", 3.0)
+	wantString(t, got, "abc")
+
+	got, _ = callFn(t, "RIGHT", "abcdef", 2.0)
+	wantString(t, got, "ef")
+
+	got, _ = callFn(t, "MID", "abcdef", 2.0, 3.0) // 1-based start
+	wantString(t, got, "bcd")
+
+	got, _ = callFn(t, "SUBSTR", "abcdef", 2.0, 3.0)
+	wantString(t, got, "bcd")
+
+	got, _ = callFn(t, "REPLACE", "foo bar foo", "foo", "baz")
+	wantString(t, got, "baz bar baz")
+
+	got, _ = callFn(t, "FIND", "bar", "foo bar baz")
+	wantFloat(t, got, 5) // 1-based, "bar" starts at position 5
+
+	got, _ = callFn(t, "FIND", "qux", "foo bar baz")
+	wantFloat(t, got, 0) // not found -> 0
+
+	got, _ = callFn(t, "CONTAINS", "hello world", "world")
+	wantBool(t, got, true)
+
+	got, _ = callFn(t, "STARTSWITH", "hello world", "hello")
+	wantBool(t, got, true)
+
+	got, _ = callFn(t, "ENDSWITH", "hello world", "world")
+	wantBool(t, got, true)
+
+	got, _ = callFn(t, "REGEX_MATCH", "abc123", `\d+`)
+	wantBool(t, got, true)
+
+	got, _ = callFn(t, "REGEX_MATCH", "abc", `\d+`)
+	wantBool(t, got, false)
+
+	got, _ = callFn(t, "REPEAT", "ab", 3.0)
+	wantString(t, got, "ababab")
+}
+
+func TestStringEdgeCases(t *testing.T) {
+	// nil input -> empty string semantics
+	got, err := callFn(t, "LEN", nil)
+	if err != nil {
+		t.Fatalf("LEN(nil) errored: %v", err)
+	}
+	wantFloat(t, got, 0)
+
+	// Slicing past the end clamps cleanly.
+	got, _ = callFn(t, "LEFT", "ab", 10.0)
+	wantString(t, got, "ab")
+
+	got, _ = callFn(t, "RIGHT", "ab", 10.0)
+	wantString(t, got, "ab")
+
+	got, _ = callFn(t, "MID", "abcdef", 100.0, 5.0)
+	wantString(t, got, "")
+
+	// Negative count for REPEAT errors out.
+	if _, err := callFn(t, "REPEAT", "x", -1.0); err == nil {
+		t.Fatal("REPEAT with negative count should error")
+	}
+
+	// Bad regex pattern errors.
+	if _, err := callFn(t, "REGEX_MATCH", "abc", "(["); err == nil {
+		t.Fatal("REGEX_MATCH with bad pattern should error")
+	}
+}
+
+// ---------------------------------------------------- Type conversion ----
+
+func TestTypeConversionFunctions(t *testing.T) {
+	got, _ := callFn(t, "TONUM", "42.5")
+	wantFloat(t, got, 42.5)
+
+	got, _ = callFn(t, "TONUM", "not a number")
+	if got != nil {
+		t.Fatalf("TONUM('not a number') should return nil, got %v", got)
+	}
+
+	got, _ = callFn(t, "VALUE", "  17  ")
+	wantFloat(t, got, 17)
+
+	got, _ = callFn(t, "TOSTR", 3.14)
+	wantString(t, got, "3.14")
+
+	got, _ = callFn(t, "TOSTR", 3.14159, "%.2f")
+	wantString(t, got, "3.14")
+
+	got, _ = callFn(t, "TEXT", 42, "%05d")
+	wantString(t, got, "00042")
+
+	got, _ = callFn(t, "TOBOOL", "yes")
+	wantBool(t, got, true)
+
+	got, _ = callFn(t, "TOBOOL", "no")
+	wantBool(t, got, false)
+
+	// COALESCE
+	got, _ = callFn(t, "COALESCE", nil, nil, "first", "second")
+	wantString(t, got, "first")
+
+	// COALESCE skips NaN
+	got, _ = callFn(t, "COALESCE", math.NaN(), nil, 7.0)
+	wantFloat(t, got, 7)
+
+	// COALESCE all nil -> nil
+	got, _ = callFn(t, "COALESCE", nil, nil)
+	if got != nil {
+		t.Fatalf("COALESCE(nil, nil) should return nil, got %v", got)
+	}
+
+	// IFNULL
+	got, _ = callFn(t, "IFNULL", nil, "fallback")
+	wantString(t, got, "fallback")
+
+	got, _ = callFn(t, "IFNULL", "value", "fallback")
+	wantString(t, got, "value")
+}
+
+// ----------------------------------------------------------- DateTime ----
+
+func TestDateTimeFunctions(t *testing.T) {
+	d := time.Date(2024, 7, 15, 10, 30, 0, 0, time.UTC) // Monday
+
+	got, _ := callFn(t, "YEAR", d)
+	wantFloat(t, got, 2024)
+
+	got, _ = callFn(t, "MONTH", d)
+	wantFloat(t, got, 7)
+
+	got, _ = callFn(t, "DAYOFMONTH", d)
+	wantFloat(t, got, 15)
+
+	got, _ = callFn(t, "WEEKDAY", d)
+	wantFloat(t, got, float64(time.Monday)) // 1
+
+	// String input gets parsed automatically.
+	got, _ = callFn(t, "YEAR", "2024-07-15")
+	wantFloat(t, got, 2024)
+
+	// DATEDIFF: d1 - d2 in chosen unit.
+	d1 := time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)
+	d2 := time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)
+	got, _ = callFn(t, "DATEDIFF", d1, d2, "day")
+	wantFloat(t, got, 5)
+
+	got, _ = callFn(t, "DATEDIFF", d1, d2, "hour")
+	wantFloat(t, got, 120)
+
+	// DATEADD: shift forward.
+	got, err := callFn(t, "DATEADD", d, 10.0, "day")
+	if err != nil {
+		t.Fatalf("DATEADD error: %v", err)
+	}
+	added, ok := got.(time.Time)
+	if !ok {
+		t.Fatalf("DATEADD: expected time.Time, got %T", got)
+	}
+	if added.Day() != 25 {
+		t.Fatalf("DATEADD +10 days: expected day 25, got %v", added)
+	}
+
+	got, err = callFn(t, "DATEADD", d, 1.0, "month")
+	if err != nil {
+		t.Fatalf("DATEADD error: %v", err)
+	}
+	added = got.(time.Time)
+	if int(added.Month()) != 8 {
+		t.Fatalf("DATEADD +1 month: expected August, got %v", added.Month())
+	}
+
+	// FORMAT_DATE
+	got, _ = callFn(t, "FORMAT_DATE", d, "2006-01-02")
+	wantString(t, got, "2024-07-15")
+}
+
+func TestDateTimeErrors(t *testing.T) {
+	if _, err := callFn(t, "YEAR", "not-a-date"); err == nil {
+		t.Fatal("YEAR with bad string should error")
+	}
+	if _, err := callFn(t, "DATEDIFF", time.Now(), time.Now(), "fortnights"); err == nil {
+		t.Fatal("DATEDIFF with unknown unit should error")
+	}
+	if _, err := callFn(t, "DATEADD", time.Now(), 1.0, "fortnights"); err == nil {
+		t.Fatal("DATEADD with unknown unit should error")
+	}
+}
+
+// --------------------------------------------------- Statistical aggs ----
+
+func TestAggregateStatFunctions(t *testing.T) {
+	// Single column.
+	col := []any{1.0, 2.0, 3.0, 4.0, 5.0}
+
+	got, _ := callAgg(t, "MEDIAN", col)
+	wantFloat(t, got, 3)
+
+	got, _ = callAgg(t, "MEDIAN", []any{1.0, 2.0, 3.0, 4.0})
+	wantFloat(t, got, 2.5)
+
+	// Sample variance of {1..5} = 2.5; population variance = 2.0
+	got, _ = callAgg(t, "VAR", col)
+	wantFloat(t, got, 2.5)
+
+	got, _ = callAgg(t, "VARP", col)
+	wantFloat(t, got, 2.0)
+
+	got, _ = callAgg(t, "STDEV", col)
+	wantFloat(t, got, math.Sqrt(2.5))
+
+	got, _ = callAgg(t, "STDEVP", col)
+	wantFloat(t, got, math.Sqrt(2.0))
+
+	// nil values are skipped, mirroring SUM/AVG semantics.
+	got, _ = callAgg(t, "MEDIAN", []any{1.0, nil, 2.0, nil, 3.0})
+	wantFloat(t, got, 2)
+
+	// Empty input -> nil.
+	if got, _ := callAgg(t, "MEDIAN", []any{}); got != nil {
+		t.Fatalf("MEDIAN on empty -> nil expected, got %v", got)
+	}
+
+	// VAR requires >=2 values.
+	if _, err := callAgg(t, "VAR", []any{1.0}); err == nil {
+		t.Fatal("VAR with 1 value should error")
+	}
+
+	// VARP works with single value.
+	got, _ = callAgg(t, "VARP", []any{5.0})
+	wantFloat(t, got, 0)
+}

--- a/internal/ccl/stdlib_math.go
+++ b/internal/ccl/stdlib_math.go
@@ -1,0 +1,204 @@
+package ccl
+
+import (
+	"fmt"
+	"math"
+)
+
+// registerMathFunctions registers Excel/SQL-style scalar math functions.
+// All functions accept any value coercible to float64 via toFloat64; on
+// failure they return a typed error so the evaluator can surface it.
+func registerMathFunctions() {
+	registerFunction("ABS", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("ABS requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("ABS: cannot convert %T to number", args[0])
+		}
+		return math.Abs(f), nil
+	})
+
+	registerFunction("ROUND", func(args ...any) (any, error) {
+		if len(args) < 1 || len(args) > 2 {
+			return nil, fmt.Errorf("ROUND requires 1 or 2 arguments")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("ROUND: cannot convert %T to number", args[0])
+		}
+		digits := 0
+		if len(args) == 2 {
+			d, ok := toFloat64(args[1])
+			if !ok {
+				return nil, fmt.Errorf("ROUND: digits arg must be a number, got %T", args[1])
+			}
+			digits = int(d)
+		}
+		shift := math.Pow(10, float64(digits))
+		return math.Round(f*shift) / shift, nil
+	})
+
+	registerFunction("FLOOR", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("FLOOR requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("FLOOR: cannot convert %T to number", args[0])
+		}
+		return math.Floor(f), nil
+	})
+
+	registerFunction("CEIL", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("CEIL requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("CEIL: cannot convert %T to number", args[0])
+		}
+		return math.Ceil(f), nil
+	})
+
+	registerFunction("TRUNC", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("TRUNC requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("TRUNC: cannot convert %T to number", args[0])
+		}
+		return math.Trunc(f), nil
+	})
+
+	registerFunction("MOD", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("MOD requires 2 arguments")
+		}
+		a, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("MOD: cannot convert %T to number", args[0])
+		}
+		b, ok := toFloat64(args[1])
+		if !ok {
+			return nil, fmt.Errorf("MOD: cannot convert %T to number", args[1])
+		}
+		if b == 0 {
+			return nil, fmt.Errorf("MOD: division by zero")
+		}
+		return math.Mod(a, b), nil
+	})
+
+	registerFunction("POW", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("POW requires 2 arguments")
+		}
+		base, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("POW: cannot convert %T to number", args[0])
+		}
+		exp, ok := toFloat64(args[1])
+		if !ok {
+			return nil, fmt.Errorf("POW: cannot convert %T to number", args[1])
+		}
+		return math.Pow(base, exp), nil
+	})
+
+	registerFunction("SQRT", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("SQRT requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("SQRT: cannot convert %T to number", args[0])
+		}
+		if f < 0 {
+			return nil, fmt.Errorf("SQRT: cannot take square root of negative number %v", f)
+		}
+		return math.Sqrt(f), nil
+	})
+
+	registerFunction("LN", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("LN requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("LN: cannot convert %T to number", args[0])
+		}
+		if f <= 0 {
+			return nil, fmt.Errorf("LN: cannot take natural log of non-positive number %v", f)
+		}
+		return math.Log(f), nil
+	})
+
+	// LOG matches Excel: LOG(x) defaults to base 10; LOG(x, base) uses given base.
+	registerFunction("LOG", func(args ...any) (any, error) {
+		if len(args) < 1 || len(args) > 2 {
+			return nil, fmt.Errorf("LOG requires 1 or 2 arguments")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("LOG: cannot convert %T to number", args[0])
+		}
+		if f <= 0 {
+			return nil, fmt.Errorf("LOG: cannot take log of non-positive number %v", f)
+		}
+		if len(args) == 1 {
+			return math.Log10(f), nil
+		}
+		base, ok := toFloat64(args[1])
+		if !ok {
+			return nil, fmt.Errorf("LOG: cannot convert base %T to number", args[1])
+		}
+		if base <= 0 || base == 1 {
+			return nil, fmt.Errorf("LOG: invalid base %v", base)
+		}
+		return math.Log(f) / math.Log(base), nil
+	})
+
+	registerFunction("LOG10", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("LOG10 requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("LOG10: cannot convert %T to number", args[0])
+		}
+		if f <= 0 {
+			return nil, fmt.Errorf("LOG10: cannot take log of non-positive number %v", f)
+		}
+		return math.Log10(f), nil
+	})
+
+	registerFunction("EXP", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("EXP requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("EXP: cannot convert %T to number", args[0])
+		}
+		return math.Exp(f), nil
+	})
+
+	registerFunction("SIGN", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("SIGN requires 1 argument")
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, fmt.Errorf("SIGN: cannot convert %T to number", args[0])
+		}
+		switch {
+		case f > 0:
+			return 1.0, nil
+		case f < 0:
+			return -1.0, nil
+		default:
+			return 0.0, nil
+		}
+	})
+}

--- a/internal/ccl/stdlib_string.go
+++ b/internal/ccl/stdlib_string.go
@@ -1,0 +1,227 @@
+package ccl
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// toString converts a value to a string for use in CCL string functions.
+// nil becomes the empty string. Other scalars use fmt.Sprint to mirror CONCAT.
+func toString(val any) string {
+	if val == nil {
+		return ""
+	}
+	if s, ok := val.(string); ok {
+		return s
+	}
+	return fmt.Sprint(val)
+}
+
+// runeAt returns a substring [start, start+length) measured in runes.
+// Behaves like Excel: clamps to bounds; returns "" if start is past end.
+// start is 0-based here (callers convert from 1-based MID/SUBSTR).
+func runeSlice(s string, start, length int) string {
+	if length <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	n := len(runes)
+	if start < 0 {
+		start = 0
+	}
+	if start >= n {
+		return ""
+	}
+	end := start + length
+	if end > n {
+		end = n
+	}
+	return string(runes[start:end])
+}
+
+// registerStringFunctions registers Excel/SQL-style scalar string functions.
+// All functions are rune-aware; LEN counts runes, LEFT/RIGHT/MID slice by rune.
+func registerStringFunctions() {
+	registerFunction("LEN", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("LEN requires 1 argument")
+		}
+		return float64(utf8.RuneCountInString(toString(args[0]))), nil
+	})
+
+	registerFunction("UPPER", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("UPPER requires 1 argument")
+		}
+		return strings.ToUpper(toString(args[0])), nil
+	})
+
+	registerFunction("LOWER", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("LOWER requires 1 argument")
+		}
+		return strings.ToLower(toString(args[0])), nil
+	})
+
+	registerFunction("TRIM", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("TRIM requires 1 argument")
+		}
+		return strings.TrimSpace(toString(args[0])), nil
+	})
+
+	registerFunction("LTRIM", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("LTRIM requires 1 argument")
+		}
+		return strings.TrimLeft(toString(args[0]), " \t\n\r"), nil
+	})
+
+	registerFunction("RTRIM", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("RTRIM requires 1 argument")
+		}
+		return strings.TrimRight(toString(args[0]), " \t\n\r"), nil
+	})
+
+	registerFunction("LEFT", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("LEFT requires 2 arguments")
+		}
+		s := toString(args[0])
+		n, ok := toFloat64(args[1])
+		if !ok {
+			return nil, fmt.Errorf("LEFT: count arg must be a number, got %T", args[1])
+		}
+		return runeSlice(s, 0, int(n)), nil
+	})
+
+	registerFunction("RIGHT", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("RIGHT requires 2 arguments")
+		}
+		s := toString(args[0])
+		n, ok := toFloat64(args[1])
+		if !ok {
+			return nil, fmt.Errorf("RIGHT: count arg must be a number, got %T", args[1])
+		}
+		count := int(n)
+		if count <= 0 {
+			return "", nil
+		}
+		runes := []rune(s)
+		if count >= len(runes) {
+			return s, nil
+		}
+		return string(runes[len(runes)-count:]), nil
+	})
+
+	// MID(s, start, length) — start is 1-based, matching Excel.
+	mid := func(args ...any) (any, error) {
+		if len(args) != 3 {
+			return nil, fmt.Errorf("requires 3 arguments")
+		}
+		s := toString(args[0])
+		start, ok := toFloat64(args[1])
+		if !ok {
+			return nil, fmt.Errorf("start arg must be a number, got %T", args[1])
+		}
+		length, ok := toFloat64(args[2])
+		if !ok {
+			return nil, fmt.Errorf("length arg must be a number, got %T", args[2])
+		}
+		startIdx := int(start) - 1 // convert to 0-based
+		return runeSlice(s, startIdx, int(length)), nil
+	}
+	registerFunction("MID", func(args ...any) (any, error) {
+		v, err := mid(args...)
+		if err != nil {
+			return nil, fmt.Errorf("MID %v", err)
+		}
+		return v, nil
+	})
+	registerFunction("SUBSTR", func(args ...any) (any, error) {
+		v, err := mid(args...)
+		if err != nil {
+			return nil, fmt.Errorf("SUBSTR %v", err)
+		}
+		return v, nil
+	})
+
+	registerFunction("REPLACE", func(args ...any) (any, error) {
+		if len(args) != 3 {
+			return nil, fmt.Errorf("REPLACE requires 3 arguments")
+		}
+		s := toString(args[0])
+		old := toString(args[1])
+		newStr := toString(args[2])
+		return strings.ReplaceAll(s, old, newStr), nil
+	})
+
+	// FIND(needle, haystack) returns 1-based position; 0 if not found.
+	registerFunction("FIND", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("FIND requires 2 arguments")
+		}
+		needle := toString(args[0])
+		haystack := toString(args[1])
+		idx := strings.Index(haystack, needle)
+		if idx < 0 {
+			return 0.0, nil
+		}
+		// Convert byte index to 1-based rune position.
+		return float64(utf8.RuneCountInString(haystack[:idx]) + 1), nil
+	})
+
+	registerFunction("CONTAINS", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("CONTAINS requires 2 arguments")
+		}
+		return strings.Contains(toString(args[0]), toString(args[1])), nil
+	})
+
+	registerFunction("STARTSWITH", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("STARTSWITH requires 2 arguments")
+		}
+		return strings.HasPrefix(toString(args[0]), toString(args[1])), nil
+	})
+
+	registerFunction("ENDSWITH", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("ENDSWITH requires 2 arguments")
+		}
+		return strings.HasSuffix(toString(args[0]), toString(args[1])), nil
+	})
+
+	registerFunction("REGEX_MATCH", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("REGEX_MATCH requires 2 arguments (string, pattern)")
+		}
+		s := toString(args[0])
+		pat := toString(args[1])
+		re, err := regexp.Compile(pat)
+		if err != nil {
+			return nil, fmt.Errorf("REGEX_MATCH: invalid pattern: %w", err)
+		}
+		return re.MatchString(s), nil
+	})
+
+	registerFunction("REPEAT", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("REPEAT requires 2 arguments")
+		}
+		s := toString(args[0])
+		n, ok := toFloat64(args[1])
+		if !ok {
+			return nil, fmt.Errorf("REPEAT: count arg must be a number, got %T", args[1])
+		}
+		count := int(n)
+		if count < 0 {
+			return nil, fmt.Errorf("REPEAT: negative count %d", count)
+		}
+		return strings.Repeat(s, count), nil
+	})
+}

--- a/internal/ccl/stdlib_typeconv.go
+++ b/internal/ccl/stdlib_typeconv.go
@@ -1,0 +1,113 @@
+package ccl
+
+import (
+	"fmt"
+	"math"
+)
+
+// registerTypeConversionFunctions registers value coercion and null-handling
+// helpers (TONUM/VALUE, TOSTR/TEXT, TOBOOL, COALESCE, IFNULL).
+//
+// IFNULL differs from IFNA: IFNA only triggers on float NaN or the string
+// "#N/A", while IFNULL replaces actual nil values.
+func registerTypeConversionFunctions() {
+	tonum := func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("requires 1 argument")
+		}
+		// Treat nil as nil (caller can wrap with COALESCE if they want a default).
+		if args[0] == nil {
+			return nil, nil
+		}
+		f, ok := toFloat64(args[0])
+		if !ok {
+			return nil, nil
+		}
+		return f, nil
+	}
+	registerFunction("TONUM", func(args ...any) (any, error) {
+		v, err := tonum(args...)
+		if err != nil {
+			return nil, fmt.Errorf("TONUM %v", err)
+		}
+		return v, nil
+	})
+	registerFunction("VALUE", func(args ...any) (any, error) {
+		v, err := tonum(args...)
+		if err != nil {
+			return nil, fmt.Errorf("VALUE %v", err)
+		}
+		return v, nil
+	})
+
+	// TOSTR / TEXT: 1-arg forms convert to string with default formatting;
+	// 2-arg form treats the second arg as a Go fmt verb format (e.g. "%.2f").
+	tostr := func(args ...any) (any, error) {
+		if len(args) < 1 || len(args) > 2 {
+			return nil, fmt.Errorf("requires 1 or 2 arguments")
+		}
+		if len(args) == 1 {
+			return toString(args[0]), nil
+		}
+		format, ok := args[1].(string)
+		if !ok {
+			return nil, fmt.Errorf("format arg must be a string, got %T", args[1])
+		}
+		return fmt.Sprintf(format, args[0]), nil
+	}
+	registerFunction("TOSTR", func(args ...any) (any, error) {
+		v, err := tostr(args...)
+		if err != nil {
+			return nil, fmt.Errorf("TOSTR %v", err)
+		}
+		return v, nil
+	})
+	registerFunction("TEXT", func(args ...any) (any, error) {
+		v, err := tostr(args...)
+		if err != nil {
+			return nil, fmt.Errorf("TEXT %v", err)
+		}
+		return v, nil
+	})
+
+	registerFunction("TOBOOL", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("TOBOOL requires 1 argument")
+		}
+		if args[0] == nil {
+			return nil, nil
+		}
+		b, ok := toBool(args[0])
+		if !ok {
+			return nil, nil
+		}
+		return b, nil
+	})
+
+	// COALESCE returns the first non-nil, non-NaN argument; otherwise nil.
+	registerFunction("COALESCE", func(args ...any) (any, error) {
+		if len(args) < 1 {
+			return nil, fmt.Errorf("COALESCE requires at least 1 argument")
+		}
+		for _, a := range args {
+			if a == nil {
+				continue
+			}
+			if f, ok := a.(float64); ok && math.IsNaN(f) {
+				continue
+			}
+			return a, nil
+		}
+		return nil, nil
+	})
+
+	registerFunction("IFNULL", func(args ...any) (any, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("IFNULL requires 2 arguments")
+		}
+		if args[0] == nil {
+			return args[1], nil
+		}
+		return args[0], nil
+	})
+}


### PR DESCRIPTION
## Summary

Implements the proposal in #154. Expands the CCL standard library from ~14 functions to ~50, covering the five categories called out in the issue — without touching the parser, evaluator, or compiler.

- **Math** (`stdlib_math.go`): `ABS`, `ROUND`, `FLOOR`, `CEIL`, `TRUNC`, `MOD`, `POW`, `SQRT`, `LN`, `LOG`, `LOG10`, `EXP`, `SIGN`
- **String** (`stdlib_string.go`, rune-aware): `LEN`, `UPPER`, `LOWER`, `TRIM`/`LTRIM`/`RTRIM`, `LEFT`, `RIGHT`, `MID`/`SUBSTR` (1-based like Excel), `REPLACE`, `FIND` (1-based, `0` if missing), `CONTAINS`, `STARTSWITH`, `ENDSWITH`, `REGEX_MATCH`, `REPEAT`
- **Type / null** (`stdlib_typeconv.go`): `TONUM`/`VALUE`, `TOSTR`/`TEXT` (optional Go `fmt` verb), `TOBOOL`, `COALESCE`, `IFNULL` (distinct from `IFNA`)
- **Date** (`stdlib_datetime.go`): `YEAR`, `MONTH`, `DAYOFMONTH`, `WEEKDAY`, `DATEDIFF`, `DATEADD`, `FORMAT_DATE`
- **Aggregates** (`stdlib_aggregates.go`): `MEDIAN`, `STDEV`/`STDEVP`, `VAR`/`VARP` (sample requires ≥2; `nil` skipped, matching `SUM`/`AVG`)

All new functions register through the existing `registerFunction` / `registerAggregateFunction` paths, so they automatically work via `AddColUsingCCL`, `ExecuteCCL`, `MapContext`, and `parquet.FilterWithCCL` / `parquet.ApplyCCL`.

## Why this is safe

- No parser, tokenizer, evaluator, or compiler changes.
- `RegisterStandardFunctions()` keeps its public signature; new helpers are factored into private `register*Functions()` calls at the top of the body.
- No new external dependencies; `gonum` was already direct but isn't pulled into `internal/ccl` — variance is implemented directly to keep the package's import graph minimal.
- All existing CCL tests still pass; new functions are purely additive.

## Test plan

- [x] `go test ./internal/ccl/...` — passes (~80 new unit cases for happy path, edge cases, and typed errors)
- [x] `go test .` — root package passes; new `datatable_ccl_stdlib_test.go` runs `AddColUsingCCL` and a multi-statement `ExecuteCCL` email-cleanup pipeline end-to-end
- [x] `go test ./...` — full suite green (38 packages, 0 failures)
- [x] `go vet ./...` — clean
- [ ] CI: `golangci-lint run` and `govulncheck ./...`

## Out-of-scope (deliberately punted, left as future issues)

- `SUMIF` / `COUNTIF` / `AVGIF` — these need either an evaluator-callable string-condition path or a real lambda syntax; punting per the issue's "≥80% of functions" acceptance criterion.
- Re-exporting `RegisterFunction` from `engine/ccl` for users who want custom functions without hitting `internal/`.
- User-defined functions in the CCL grammar.

## Docs

- `Docs/CCL.md` Functions section now includes Math, String, Type-Conversion, and Date subsections with example tables.
- Aggregate Functions section adds `MEDIAN`, `STDEV`/`STDEVP`, `VAR`/`VARP` entries.

Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)