### PR TITLE
feat(datatable): add GroupBy + Aggregate (split-apply-combine)

### DIFF
--- a/Docs/DataTable.md
+++ b/Docs/DataTable.md
@@ -10,6 +10,7 @@ DataTable is the core data structure of Insyra for handling structured data. It 
 - [Data Saving](#data-saving)
 - [Data Operations](#data-operations)
   - [Merge](#merge)
+  - [GroupBy](#groupby)
 - [Data Replacement](#data-replacement)
 - [Column Calculation](#column-calculation)
 - [Searching](#searching)
@@ -728,6 +729,88 @@ resRight, _ := dt1.Merge(dt2, insyra.MergeDirectionHorizontal, insyra.MergeModeR
 // B, 2, 10
 // C, 3, 20
 // D, <nil>, 30
+```
+
+### GroupBy
+
+```go
+func (dt *DataTable) GroupBy(keyCols ...string) *GroupedDataTable
+func (g *GroupedDataTable) Aggregate(configs ...AggregateConfig) *DataTable
+func (g *GroupedDataTable) AggregateAll(op AggregateOp) *DataTable
+func (g *GroupedDataTable) Count() *DataTable
+```
+
+**Description:** Splits the DataTable into groups by one or more key columns and applies aggregate functions to each group ("split-apply-combine"). The result is a new DataTable with one row per unique key combination — key columns first (in `GroupBy` order), then the aggregate columns (in `Aggregate` order). Group order in the output follows the order in which each key combination is first seen during a single linear scan; `nil` keys form their own group, and `int(1)` is kept distinct from the string `"1"`.
+
+**`AggregateConfig` fields:**
+
+- `SourceCol`: The column to aggregate. Resolved by name first, then as an Excel-style index (`"A"`, `"B"`, ...). Required for every op except `OpCountAll`.
+- `As`: Output column name. When empty it is auto-named `"<source>_<op>"` (e.g. `"revenue_sum"`).
+- `Op`: One of the `AggregateOp` constants below.
+- `Custom`: Used only when `Op == OpCustom`. The provided function receives a `*DataList` containing the source-column values of the group, in original row order, including `nil` entries.
+
+**Supported `AggregateOp`:**
+
+| Op | Behavior |
+|---|---|
+| `OpSum` | Sum of numeric values; non-numeric and `nil` skipped |
+| `OpMean` | Arithmetic mean of numeric values |
+| `OpMedian` | Median of numeric values |
+| `OpMin` / `OpMax` | Numeric min / max |
+| `OpCount` | Count of **non-nil** values |
+| `OpCountAll` | Count of **all** rows in the group (group size) |
+| `OpStdev` / `OpStdevP` | Sample / population standard deviation |
+| `OpVar` / `OpVarP` | Sample / population variance |
+| `OpFirst` / `OpLast` | First / last **non-nil** value in original row order |
+| `OpNUnique` | Distinct non-nil value count |
+| `OpCustom` | User-supplied `Custom func(group *DataList) any` |
+
+**Errors:** Unknown key columns, unknown source columns, missing `Custom` for `OpCustom`, empty configs, and empty key lists are reported via the parent `dt.Err()` instance-level error. The aggregate output is still returned (with affected columns nil-filled or empty), so callers can inspect partial results and continue chaining.
+
+**Example (single key, multiple aggregates):**
+
+```go
+dt := insyra.NewDataTable(
+    insyra.NewDataList("east", "east", "west", "west", "south").SetName("region"),
+    insyra.NewDataList(100, 200, 50, 75, 300).SetName("revenue"),
+    insyra.NewDataList(1, 2, 3, 4, 5).SetName("qty"),
+)
+
+report := dt.GroupBy("region").Aggregate(
+    insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpSum,  As: "total_rev"},
+    insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpMean, As: "avg_rev"},
+    insyra.AggregateConfig{SourceCol: "qty",     Op: insyra.OpSum,  As: "total_qty"},
+)
+// report columns: region, total_rev, avg_rev, total_qty
+// report rows:    east 300 150 3 / west 125 62.5 7 / south 300 300 5
+```
+
+**Example (multiple keys, custom aggregate):**
+
+```go
+weighted := dt.GroupBy("region", "product").Aggregate(
+    insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpSum},  // auto-named "revenue_sum"
+    insyra.AggregateConfig{
+        SourceCol: "price",
+        As:        "wprice",
+        Op:        insyra.OpCustom,
+        Custom: func(group *insyra.DataList) any {
+            // Custom receives the group's column slice as a DataList. nil
+            // entries are preserved; you handle them.
+            return group.Mean()
+        },
+    },
+)
+```
+
+**Pipeline:** `GroupBy + Aggregate` composes naturally with `FilterRows` and `SortBy`:
+
+```go
+top := dt.
+    FilterRows(func(_, _ string, x any) bool { return true /* ... */ }).
+    GroupBy("region").
+    Aggregate(insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpSum, As: "total"}).
+    SortBy(insyra.DataTableSortConfig{ColumnName: "total", Descending: true})
 ```
 
 ### AppendCols

--- a/Docs/cli-dsl.md
+++ b/Docs/cli-dsl.md
@@ -228,6 +228,21 @@ Run:
 insyra --env demo run pipeline.isr
 ```
 
+### B2. GroupBy aggregations
+
+`groupby <var> by <col1>[,<col2>...] agg <spec> [<spec> ...] [as <var>]` runs split-apply-combine. Each `<spec>` is `<col>:<op>[:<alias>]`, plus the shorthand `count` for "row count per group". Supported ops: `sum`, `mean` (alias `avg`), `median`, `min`, `max`, `count`, `countall`, `std` (`stdev`), `stdp` (`stdevp`), `var`, `varp`, `first`, `last`, `nunique`. Aliases default to `<col>_<op>`.
+
+```text
+load sales.csv as sales
+groupby sales by region agg revenue:sum:total_rev qty:mean as report
+show report
+
+# Multi-key + count + named aggregate
+groupby sales by region,product agg revenue:sum count as report2
+```
+
+The result is a fresh DataTable with one row per group; key columns appear first (in `by` order), aggregate columns next (in `agg` order).
+
 ### C. Go `engine/dsl` session flow
 
 ```go
@@ -265,7 +280,7 @@ High-level command map:
 - **Environment**: `env`, `vars`, `drop`, `clone`, `rename`, `shape`, `types`, `show`, `summary`
 - **Data IO / Creation**: `newdl`, `newdt`, `load`, `read`, `save`, `convert`
 - **DataTable Structure / Access**: `addcol`, `addrow`, `dropcol`, `droprow`, `swap`, `transpose`, `rows`, `cols`, `row`, `col`, `get`, `set`, `setrownames`, `setcolnames`
-- **Data Processing**: `filter`, `sort`, `sample`, `find`, `replace`, `clean`, `merge`, `ccl`, `addcolccl`
+- **Data Processing**: `filter`, `sort`, `sample`, `find`, `replace`, `clean`, `merge`, `groupby`, `ccl`, `addcolccl`
 - **DataList Stats**: `sum`, `mean`, `median`, `mode`, `stdev`, `var`, `min`, `max`, `range`, `quartile`, `iqr`, `percentile`, `count`, `counter`, `corr`, `cov`, `corrmatrix`, `skewness`, `kurtosis`
 - **Time Series / Transforms**: `rank`, `normalize`, `standardize`, `reverse`, `upper`, `lower`, `capitalize`, `parsenums`, `parsestrings`, `movavg`, `expsmooth`, `diff`, `fillnan`
 - **Modeling / Viz / Fetch**: `regression`, `pca`, `kmeans`, `hclust`, `cutree`, `dbscan`, `silhouette`, `ttest`, `ztest`, `anova`, `ftest`, `chisq`, `plot`, `fetch`
@@ -312,6 +327,7 @@ Source policy:
 | `find` | `find <var> <value>` | Find rows containing value |
 | `ftest` | `ftest var\|levene\|bartlett ...` | F-test commands |
 | `get` | `get <var> <row> <col>` | Get single element from DataTable |
+| `groupby` | `groupby <var> by <col1>[,<col2>...] agg <col>:<op>[:<alias>] [<col>:<op>[:<alias>] ...] [as <var>]` | Group a DataTable and aggregate columns (split-apply-combine) |
 | `help` | `help [command]` | Show command help |
 | `history` | `history` | Show command history |
 | `iqr` | `iqr <var>` | DataList IQR |

--- a/Docs/isr.md
+++ b/Docs/isr.md
@@ -771,6 +771,39 @@ CCL(cclStatements string) *dt
 
 > **Note**: For detailed CCL syntax and features, see the [CCL Documentation](CCL.md).
 
+#### Grouping and Aggregating
+
+```go
+// Group rows by one or more key columns and apply aggregations.
+report := isr.DT.From(isr.Rows{
+    {"region": "east", "revenue": 100, "qty": 1},
+    {"region": "east", "revenue": 200, "qty": 2},
+    {"region": "west", "revenue": 50,  "qty": 3},
+}).GroupBy("region").Aggregate(
+    insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpSum,  As: "total_rev"},
+    insyra.AggregateConfig{SourceCol: "qty",     Op: insyra.OpMean, As: "avg_qty"},
+)
+// report columns: region, total_rev, avg_qty
+```
+
+**Method:**
+
+```go
+GroupBy(keyCols ...string) *insyra.GroupedDataTable
+```
+
+**Description:** Splits the DataTable by the value combinations of the given key columns and returns an intermediate object whose `Aggregate`, `AggregateAll`, or `Count` methods produce a new `*insyra.DataTable`. See [DataTable.GroupBy](DataTable.md#groupby) for the full list of supported aggregate operations.
+
+**Parameters:**
+
+- One or more column references (name or Excel-style index, e.g. `"A"`).
+
+**Returns:**
+
+- `*insyra.GroupedDataTable` — call `.Aggregate(...)`, `.AggregateAll(op)`, or `.Count()` to materialize a `*insyra.DataTable`.
+
+**Equivalent:** `insyra.DataTable.GroupBy()`
+
 ## Advanced Features
 
 ### Named Elements

--- a/cli/commands/groupby.go
+++ b/cli/commands/groupby.go
@@ -1,0 +1,140 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	insyra "github.com/HazelnutParadise/insyra"
+)
+
+func init() {
+	_ = Register(&CommandHandler{
+		Name:        "groupby",
+		Usage:       "groupby <var> by <col1>[,<col2>...] agg <col>:<op>[:<alias>] [<col>:<op>[:<alias>] ...] [as <var>]",
+		Description: "Group a DataTable and aggregate columns",
+		Run:         runGroupByCommand,
+	})
+}
+
+func runGroupByCommand(ctx *ExecContext, args []string) error {
+	coreArgs, alias := parseAlias(args)
+	if len(coreArgs) < 5 {
+		return fmt.Errorf("usage: groupby <var> by <cols> agg <col>:<op>[:<alias>] [...] [as <var>]")
+	}
+	if !strings.EqualFold(coreArgs[1], "by") {
+		return fmt.Errorf("expected 'by' after variable name, got %q", coreArgs[1])
+	}
+	keyTokens := strings.Split(coreArgs[2], ",")
+	keys := make([]string, 0, len(keyTokens))
+	for _, k := range keyTokens {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return fmt.Errorf("groupby requires at least one key column after 'by'")
+	}
+	if !strings.EqualFold(coreArgs[3], "agg") {
+		return fmt.Errorf("expected 'agg' after key columns, got %q", coreArgs[3])
+	}
+	specs := coreArgs[4:]
+	if len(specs) == 0 {
+		return fmt.Errorf("groupby requires at least one aggregate spec after 'agg'")
+	}
+	configs := make([]insyra.AggregateConfig, 0, len(specs))
+	for _, spec := range specs {
+		cfg, err := parseAggregateSpec(spec)
+		if err != nil {
+			return err
+		}
+		configs = append(configs, cfg)
+	}
+
+	table, err := getDataTableVar(ctx, coreArgs[0])
+	if err != nil {
+		return err
+	}
+	result := table.GroupBy(keys...).Aggregate(configs...)
+	if errInfo := table.Err(); errInfo != nil {
+		// Surface the parent-level error to the user. The result is still
+		// stored so they can inspect partial output.
+		_, _ = fmt.Fprintf(ctx.Output, "warning: %s\n", errInfo.Error())
+	}
+	ctx.Vars[alias] = result
+	_, _ = fmt.Fprintf(ctx.Output, "grouped into %s (%d rows)\n", alias, result.NumRows())
+	return nil
+}
+
+// parseAggregateSpec parses a single CLI aggregate descriptor of the form
+//
+//	<col>:<op>[:<alias>]
+//
+// or, for the row-count operator that needs no source column,
+//
+//	:countall[:<alias>]
+//	count          (special-case shorthand for :countall:count)
+//
+// Aliases are auto-derived as "<col>_<op>" when omitted.
+func parseAggregateSpec(spec string) (insyra.AggregateConfig, error) {
+	var cfg insyra.AggregateConfig
+	if strings.EqualFold(spec, "count") {
+		// shorthand: total row count, no source column
+		cfg.Op = insyra.OpCountAll
+		cfg.As = "count"
+		return cfg, nil
+	}
+	parts := strings.SplitN(spec, ":", 3)
+	if len(parts) < 2 {
+		return cfg, fmt.Errorf("invalid aggregate spec %q (expected <col>:<op>[:<alias>])", spec)
+	}
+	cfg.SourceCol = strings.TrimSpace(parts[0])
+	op, err := parseAggregateOp(parts[1])
+	if err != nil {
+		return cfg, fmt.Errorf("invalid op in spec %q: %w", spec, err)
+	}
+	cfg.Op = op
+	if len(parts) == 3 {
+		cfg.As = strings.TrimSpace(parts[2])
+	}
+	if cfg.SourceCol == "" && op != insyra.OpCountAll {
+		return cfg, fmt.Errorf("invalid aggregate spec %q: source column is required for op %s", spec, op)
+	}
+	return cfg, nil
+}
+
+// parseAggregateOp accepts the canonical names plus a few well-known aliases
+// (avg / std / population variants) used by the CLI DSL.
+func parseAggregateOp(raw string) (insyra.AggregateOp, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "sum":
+		return insyra.OpSum, nil
+	case "mean", "avg":
+		return insyra.OpMean, nil
+	case "median":
+		return insyra.OpMedian, nil
+	case "min":
+		return insyra.OpMin, nil
+	case "max":
+		return insyra.OpMax, nil
+	case "count":
+		return insyra.OpCount, nil
+	case "countall":
+		return insyra.OpCountAll, nil
+	case "std", "stdev", "stddev":
+		return insyra.OpStdev, nil
+	case "stdp", "stdevp", "stddevp":
+		return insyra.OpStdevP, nil
+	case "var", "variance":
+		return insyra.OpVar, nil
+	case "varp":
+		return insyra.OpVarP, nil
+	case "first":
+		return insyra.OpFirst, nil
+	case "last":
+		return insyra.OpLast, nil
+	case "nunique":
+		return insyra.OpNUnique, nil
+	}
+	return 0, fmt.Errorf("unknown aggregate op %q", raw)
+}

--- a/cli/commands/groupby_test.go
+++ b/cli/commands/groupby_test.go
@@ -1,0 +1,174 @@
+package commands
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	insyra "github.com/HazelnutParadise/insyra"
+)
+
+func groupbyTestTable() *insyra.DataTable {
+	region := insyra.NewDataList("east", "east", "west", "west", "south")
+	region.SetName("region")
+	revenue := insyra.NewDataList(100, 200, 50, 75, 300)
+	revenue.SetName("revenue")
+	qty := insyra.NewDataList(1, 2, 3, 4, 5)
+	qty.SetName("qty")
+	t := insyra.NewDataTable()
+	t.AppendCols(region, revenue, qty)
+	return t
+}
+
+func TestRunGroupByCommand_HappyPath(t *testing.T) {
+	ctx := &ExecContext{
+		Vars:   map[string]any{"sales": groupbyTestTable()},
+		Output: &bytes.Buffer{},
+	}
+	err := runGroupByCommand(ctx, []string{
+		"sales", "by", "region",
+		"agg", "revenue:sum:total_rev", "qty:mean", "as", "report",
+	})
+	if err != nil {
+		t.Fatalf("runGroupByCommand failed: %v", err)
+	}
+	report, ok := ctx.Vars["report"].(*insyra.DataTable)
+	if !ok {
+		t.Fatalf("expected report DataTable, got %T", ctx.Vars["report"])
+	}
+	if report.NumRows() != 3 {
+		t.Fatalf("expected 3 groups, got %d", report.NumRows())
+	}
+	headers := report.ColNames()
+	wantHeaders := []string{"region", "total_rev", "qty_mean"}
+	if !reflect.DeepEqual(headers, wantHeaders) {
+		t.Fatalf("headers = %v want %v", headers, wantHeaders)
+	}
+	rev := report.GetColByName("total_rev").Data()
+	if got, _ := insyra.ToFloat64Safe(rev[0]); got != 300 {
+		t.Errorf("east total_rev = %v want 300", rev[0])
+	}
+}
+
+func TestRunGroupByCommand_MultiKey(t *testing.T) {
+	tbl := insyra.NewDataTable()
+	region := insyra.NewDataList("east", "east", "west")
+	region.SetName("region")
+	product := insyra.NewDataList("a", "b", "a")
+	product.SetName("product")
+	revenue := insyra.NewDataList(10, 20, 30)
+	revenue.SetName("revenue")
+	tbl.AppendCols(region, product, revenue)
+
+	ctx := &ExecContext{
+		Vars:   map[string]any{"t": tbl},
+		Output: &bytes.Buffer{},
+	}
+	err := runGroupByCommand(ctx, []string{
+		"t", "by", "region,product",
+		"agg", "revenue:sum",
+	})
+	if err != nil {
+		t.Fatalf("runGroupByCommand failed: %v", err)
+	}
+	out, ok := ctx.Vars["$result"].(*insyra.DataTable)
+	if !ok {
+		t.Fatalf("expected default $result DataTable, got %T", ctx.Vars["$result"])
+	}
+	if out.NumRows() != 3 {
+		t.Fatalf("expected 3 groups, got %d", out.NumRows())
+	}
+}
+
+func TestRunGroupByCommand_CountShorthand(t *testing.T) {
+	ctx := &ExecContext{
+		Vars:   map[string]any{"sales": groupbyTestTable()},
+		Output: &bytes.Buffer{},
+	}
+	err := runGroupByCommand(ctx, []string{
+		"sales", "by", "region", "agg", "count", "as", "report",
+	})
+	if err != nil {
+		t.Fatalf("runGroupByCommand failed: %v", err)
+	}
+	report := ctx.Vars["report"].(*insyra.DataTable)
+	count := report.GetColByName("count").Data()
+	want := []int{2, 2, 1}
+	for i, w := range want {
+		if count[i].(int) != w {
+			t.Errorf("count[%d] = %v want %v", i, count[i], w)
+		}
+	}
+}
+
+func TestRunGroupByCommand_InvalidUsage(t *testing.T) {
+	ctx := &ExecContext{Vars: map[string]any{}, Output: &bytes.Buffer{}}
+	if err := runGroupByCommand(ctx, []string{"only"}); err == nil {
+		t.Fatalf("expected error for too few args")
+	}
+	if err := runGroupByCommand(ctx, []string{"a", "wrong", "b", "agg", "x:sum"}); err == nil {
+		t.Fatalf("expected error when 'by' keyword is missing")
+	}
+	if err := runGroupByCommand(ctx, []string{"a", "by", "k", "wrong", "x:sum"}); err == nil {
+		t.Fatalf("expected error when 'agg' keyword is missing")
+	}
+}
+
+func TestRunGroupByCommand_UnknownVar(t *testing.T) {
+	ctx := &ExecContext{Vars: map[string]any{}, Output: &bytes.Buffer{}}
+	err := runGroupByCommand(ctx, []string{"missing", "by", "k", "agg", "x:sum"})
+	if err == nil {
+		t.Fatalf("expected error for unknown variable")
+	}
+}
+
+func TestParseAggregateSpec(t *testing.T) {
+	cases := []struct {
+		raw  string
+		op   insyra.AggregateOp
+		col  string
+		as   string
+		fail bool
+	}{
+		{"revenue:sum", insyra.OpSum, "revenue", "", false},
+		{"revenue:sum:total", insyra.OpSum, "revenue", "total", false},
+		{"qty:avg", insyra.OpMean, "qty", "", false},
+		{"price:median:p", insyra.OpMedian, "price", "p", false},
+		{"x:std", insyra.OpStdev, "x", "", false},
+		{"x:stdp", insyra.OpStdevP, "x", "", false},
+		{"x:var", insyra.OpVar, "x", "", false},
+		{"x:varp", insyra.OpVarP, "x", "", false},
+		{"x:nunique", insyra.OpNUnique, "x", "", false},
+		{"x:first", insyra.OpFirst, "x", "", false},
+		{"x:last", insyra.OpLast, "x", "", false},
+		{"count", insyra.OpCountAll, "", "count", false},
+		{":countall:total", insyra.OpCountAll, "", "total", false},
+		{"x:countall", insyra.OpCountAll, "x", "", false},
+
+		{"badspec", 0, "", "", true},
+		{"x:nope", 0, "", "", true},
+		{":sum", 0, "", "", true},
+	}
+	for _, tc := range cases {
+		cfg, err := parseAggregateSpec(tc.raw)
+		if tc.fail {
+			if err == nil {
+				t.Errorf("expected error for spec %q", tc.raw)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("spec %q: unexpected error: %v", tc.raw, err)
+			continue
+		}
+		if cfg.Op != tc.op {
+			t.Errorf("spec %q: op = %v want %v", tc.raw, cfg.Op, tc.op)
+		}
+		if cfg.SourceCol != tc.col {
+			t.Errorf("spec %q: col = %q want %q", tc.raw, cfg.SourceCol, tc.col)
+		}
+		if cfg.As != tc.as {
+			t.Errorf("spec %q: as = %q want %q", tc.raw, cfg.As, tc.as)
+		}
+	}
+}

--- a/datatable_groupby.go
+++ b/datatable_groupby.go
@@ -1,0 +1,573 @@
+package insyra
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/HazelnutParadise/insyra/internal/utils"
+)
+
+// AggregateOp identifies an aggregation operation applied per group by Aggregate.
+type AggregateOp int
+
+const (
+	// OpSum sums numeric values in the group; non-numeric and nil values are skipped.
+	OpSum AggregateOp = iota
+	// OpMean computes the arithmetic mean of numeric values in the group.
+	OpMean
+	// OpMedian computes the median of numeric values in the group.
+	OpMedian
+	// OpMin returns the minimum numeric value in the group.
+	OpMin
+	// OpMax returns the maximum numeric value in the group.
+	OpMax
+	// OpCount counts non-nil values in the group.
+	OpCount
+	// OpCountAll counts all rows in the group, including those with nil values.
+	OpCountAll
+	// OpStdev computes the sample standard deviation of numeric values in the group.
+	OpStdev
+	// OpStdevP computes the population standard deviation of numeric values in the group.
+	OpStdevP
+	// OpVar computes the sample variance of numeric values in the group.
+	OpVar
+	// OpVarP computes the population variance of numeric values in the group.
+	OpVarP
+	// OpFirst returns the first non-nil value in the group (in original row order).
+	OpFirst
+	// OpLast returns the last non-nil value in the group (in original row order).
+	OpLast
+	// OpNUnique counts the distinct non-nil values in the group.
+	OpNUnique
+	// OpCustom invokes Custom func on the group's sub-DataList for the source column.
+	OpCustom
+)
+
+// String returns the canonical short name of an AggregateOp (e.g. "sum", "mean").
+func (o AggregateOp) String() string {
+	switch o {
+	case OpSum:
+		return "sum"
+	case OpMean:
+		return "mean"
+	case OpMedian:
+		return "median"
+	case OpMin:
+		return "min"
+	case OpMax:
+		return "max"
+	case OpCount:
+		return "count"
+	case OpCountAll:
+		return "countall"
+	case OpStdev:
+		return "stdev"
+	case OpStdevP:
+		return "stdevp"
+	case OpVar:
+		return "var"
+	case OpVarP:
+		return "varp"
+	case OpFirst:
+		return "first"
+	case OpLast:
+		return "last"
+	case OpNUnique:
+		return "nunique"
+	case OpCustom:
+		return "custom"
+	}
+	return fmt.Sprintf("op(%d)", int(o))
+}
+
+// AggregateConfig describes a single aggregation operation produced by Aggregate.
+type AggregateConfig struct {
+	// SourceCol is the source column to aggregate. It is matched first by name,
+	// then by Excel-style index ("A"/"B"/...). Required for every Op except
+	// OpCountAll, where an empty SourceCol is allowed.
+	SourceCol string
+	// As is the output column name. If empty, the column is auto-named as
+	// "<source>_<op>" (e.g., "revenue_sum"). For OpCountAll without a source
+	// column, the default is "count_all".
+	As string
+	// Op selects the aggregation. See AggregateOp constants.
+	Op AggregateOp
+	// Custom is the user-provided function for OpCustom. It receives a
+	// DataList containing the values in the source column for this group
+	// (in original row order, including nil entries) and returns any value.
+	// Ignored when Op != OpCustom.
+	Custom func(group *DataList) any
+}
+
+// GroupedDataTable is the lightweight intermediate produced by DataTable.GroupBy.
+// It is not safe for concurrent use across goroutines and should be consumed by
+// calling Aggregate, AggregateAll, or Count once before reuse.
+type GroupedDataTable struct {
+	parent *DataTable
+
+	// keyColNumbers holds the numeric column index of every key column,
+	// in the order supplied to GroupBy.
+	keyColNumbers []int
+	// keyColLabels holds a friendly label per key column (column name when
+	// available, otherwise the Excel-style index used as the lookup token).
+	keyColLabels []string
+
+	// columnsSnapshot is a defensive shallow copy of the parent's columns at
+	// the moment GroupBy was called. We do not hold the parent lock during
+	// Aggregate, mirroring the existing actor-model conventions.
+	columnsSnapshot []*DataList
+
+	// rowsByGroup maps a stable string-encoded composite key to the row
+	// indices that belong to the group. Row indices reference rows in
+	// columnsSnapshot.
+	rowsByGroup map[string][]int
+
+	// groupOrder records the order in which group keys were first seen. This
+	// drives the row order of the output DataTable.
+	groupOrder []string
+
+	// groupKeyValues stores the original (typed) key values per group, so we
+	// can emit them as-is into the result DataTable rather than as their
+	// string-encoded form.
+	groupKeyValues map[string][]any
+
+	// initErr records errors encountered while building the grouping
+	// (missing columns, etc.). Aggregate propagates these to the parent
+	// DataTable's instance-level error state.
+	initErr string
+}
+
+// GroupBy splits dt into groups defined by the unique combinations of values in
+// the given key columns and returns an intermediate object that supports
+// Aggregate / AggregateAll / Count.
+//
+// Each entry in keyCols may be a column name or an Excel-style column index
+// ("A", "B", ..., "AA"). Lookups try the name first, then fall back to the
+// alphabetic index. Unknown columns are recorded on the parent DataTable's
+// Err() and Aggregate will return an empty DataTable.
+//
+// Group order in the resulting DataTable follows the order in which each key
+// combination is first seen during a single linear scan of the input rows.
+func (dt *DataTable) GroupBy(keyCols ...string) *GroupedDataTable {
+	g := &GroupedDataTable{
+		parent:         dt,
+		rowsByGroup:    map[string][]int{},
+		groupKeyValues: map[string][]any{},
+	}
+	if len(keyCols) == 0 {
+		dt.warn("GroupBy", "no key columns provided")
+		g.initErr = "GroupBy requires at least one key column"
+		return g
+	}
+	dt.AtomicDo(func(t *DataTable) {
+		// Snapshot column references so subsequent operations work without
+		// holding the actor lock. Columns are pointers; the data slices are
+		// not mutated by Aggregate, so a shallow copy is safe.
+		g.columnsSnapshot = make([]*DataList, len(t.columns))
+		copy(g.columnsSnapshot, t.columns)
+
+		g.keyColNumbers = make([]int, 0, len(keyCols))
+		g.keyColLabels = make([]string, 0, len(keyCols))
+		for _, raw := range keyCols {
+			num, label, ok := resolveColForGroup(t, raw)
+			if !ok {
+				dt.warn("GroupBy", "key column %q not found", raw)
+				g.initErr = fmt.Sprintf("GroupBy: key column %q not found", raw)
+				return
+			}
+			g.keyColNumbers = append(g.keyColNumbers, num)
+			g.keyColLabels = append(g.keyColLabels, label)
+		}
+
+		nRows := 0
+		for _, c := range t.columns {
+			if l := len(c.data); l > nRows {
+				nRows = l
+			}
+		}
+
+		// Single linear scan to assign rows to groups.
+		for row := 0; row < nRows; row++ {
+			keyVals := make([]any, len(g.keyColNumbers))
+			for i, colNum := range g.keyColNumbers {
+				if colNum < 0 || colNum >= len(t.columns) {
+					keyVals[i] = nil
+					continue
+				}
+				col := t.columns[colNum]
+				if row < len(col.data) {
+					keyVals[i] = col.data[row]
+				} else {
+					keyVals[i] = nil
+				}
+			}
+			encoded := encodeGroupKey(keyVals)
+			if _, exists := g.rowsByGroup[encoded]; !exists {
+				g.groupOrder = append(g.groupOrder, encoded)
+				g.groupKeyValues[encoded] = keyVals
+			}
+			g.rowsByGroup[encoded] = append(g.rowsByGroup[encoded], row)
+		}
+	})
+	return g
+}
+
+// resolveColForGroup matches a token to a DataTable column. It tries the
+// column name first, then the Excel-style index, and returns (colNumber,
+// displayLabel, ok). The label prefers the column's name when present.
+func resolveColForGroup(t *DataTable, token string) (int, string, bool) {
+	if num, ok := t.getColNumberByName_notAtomic(token); ok {
+		label := token
+		if name := t.columns[num].name; name != "" {
+			label = name
+		}
+		return num, label, true
+	}
+	upper := strings.ToUpper(token)
+	if num, ok := utils.ParseColIndex(upper); ok {
+		if num >= 0 && num < len(t.columns) {
+			label := upper
+			if name := t.columns[num].name; name != "" {
+				label = name
+			}
+			return num, label, true
+		}
+	}
+	return 0, token, false
+}
+
+// encodeGroupKey produces a stable, collision-resistant string encoding of a
+// composite key. We type-tag every component so that the strings "1" and the
+// integer 1 fall into distinct groups, and we use a separator that callers
+// cannot easily produce in their data.
+func encodeGroupKey(values []any) string {
+	var b strings.Builder
+	for i, v := range values {
+		if i > 0 {
+			b.WriteString("\x1e") // ASCII record separator
+		}
+		if v == nil {
+			b.WriteString("n:")
+			continue
+		}
+		switch tv := v.(type) {
+		case string:
+			b.WriteString("s:")
+			b.WriteString(tv)
+		case bool:
+			if tv {
+				b.WriteString("b:1")
+			} else {
+				b.WriteString("b:0")
+			}
+		case float32, float64:
+			f, _ := utils.ToFloat64Safe(v)
+			if math.IsNaN(f) {
+				b.WriteString("f:NaN")
+			} else {
+				fmt.Fprintf(&b, "f:%v", f)
+			}
+		case int, int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64:
+			fmt.Fprintf(&b, "i:%v", v)
+		default:
+			fmt.Fprintf(&b, "o:%T:%v", v, v)
+		}
+	}
+	return b.String()
+}
+
+// Aggregate produces a new DataTable with one row per group. The first columns
+// are the keys passed to GroupBy (in the original order); the remaining
+// columns are produced by configs (in the order passed). Custom funcs receive
+// a DataList containing the source-column values for that group, including
+// any nil entries, in the original row order.
+func (g *GroupedDataTable) Aggregate(configs ...AggregateConfig) *DataTable {
+	out := NewDataTable()
+	if g == nil {
+		return out
+	}
+	if g.initErr != "" {
+		if g.parent != nil {
+			g.parent.warn("Aggregate", "%s", g.initErr)
+		}
+		return out
+	}
+	if len(configs) == 0 {
+		if g.parent != nil {
+			g.parent.warn("Aggregate", "no aggregate configs provided")
+		}
+		return out
+	}
+
+	// Validate configs ahead of time and resolve source columns.
+	resolved := make([]aggregateResolved, len(configs))
+	for i, cfg := range configs {
+		resolved[i] = g.resolveConfig(cfg)
+		if resolved[i].err != "" && g.parent != nil {
+			g.parent.warn("Aggregate", "%s", resolved[i].err)
+		}
+	}
+
+	// Build the key columns first.
+	keyCols := make([]*DataList, len(g.keyColLabels))
+	for i, label := range g.keyColLabels {
+		keyCols[i] = NewDataList()
+		keyCols[i].SetName(label)
+	}
+
+	// Create empty result columns for each aggregate config.
+	resultCols := make([]*DataList, len(configs))
+	for i, r := range resolved {
+		col := NewDataList()
+		col.SetName(r.outputName)
+		resultCols[i] = col
+	}
+
+	// Walk groups in first-seen order and compute aggregates.
+	for _, encoded := range g.groupOrder {
+		keyVals := g.groupKeyValues[encoded]
+		for i, v := range keyVals {
+			keyCols[i].Append(v)
+		}
+		rowIdxs := g.rowsByGroup[encoded]
+		for i, r := range resolved {
+			value := g.computeAggregate(r, rowIdxs)
+			resultCols[i].Append(value)
+		}
+	}
+
+	// Append in deterministic order: keys first, then aggregates.
+	out.AppendCols(keyCols...)
+	out.AppendCols(resultCols...)
+	return out
+}
+
+// AggregateAll applies op to every column that is not a group key. The output
+// names are auto-derived (e.g., "revenue_sum"). Columns that produce no valid
+// numeric values for any group simply emit NaN, matching DataList.Sum etc.
+func (g *GroupedDataTable) AggregateAll(op AggregateOp) *DataTable {
+	if g == nil {
+		return NewDataTable()
+	}
+	if g.initErr != "" {
+		if g.parent != nil {
+			g.parent.warn("AggregateAll", "%s", g.initErr)
+		}
+		return NewDataTable()
+	}
+	if op == OpCustom {
+		if g.parent != nil {
+			g.parent.warn("AggregateAll", "OpCustom is not supported by AggregateAll")
+		}
+		return NewDataTable()
+	}
+	keySet := map[int]struct{}{}
+	for _, n := range g.keyColNumbers {
+		keySet[n] = struct{}{}
+	}
+	configs := make([]AggregateConfig, 0, len(g.columnsSnapshot))
+	for i, col := range g.columnsSnapshot {
+		if _, isKey := keySet[i]; isKey {
+			continue
+		}
+		ref := col.name
+		if ref == "" {
+			idx, ok := utils.CalcColIndex(i)
+			if !ok {
+				continue
+			}
+			ref = idx
+		}
+		configs = append(configs, AggregateConfig{SourceCol: ref, Op: op})
+	}
+	if len(configs) == 0 {
+		return NewDataTable()
+	}
+	return g.Aggregate(configs...)
+}
+
+// Count returns a DataTable with a single aggregate column ("count") that
+// holds the size of each group (including rows where every value is nil).
+func (g *GroupedDataTable) Count() *DataTable {
+	return g.Aggregate(AggregateConfig{Op: OpCountAll, As: "count"})
+}
+
+// aggregateResolved is the internal, validated form of an AggregateConfig.
+type aggregateResolved struct {
+	cfg        AggregateConfig
+	sourceCol  *DataList
+	sourceNum  int
+	hasSource  bool
+	outputName string
+	err        string
+}
+
+// resolveConfig validates a single AggregateConfig against the snapshot.
+func (g *GroupedDataTable) resolveConfig(cfg AggregateConfig) aggregateResolved {
+	r := aggregateResolved{cfg: cfg, sourceNum: -1}
+	// Source column is optional only for OpCountAll.
+	if cfg.SourceCol == "" {
+		if cfg.Op != OpCountAll {
+			r.err = fmt.Sprintf("Aggregate: SourceCol required for op %s", cfg.Op)
+			r.outputName = nonEmptyOr(cfg.As, "")
+			return r
+		}
+		r.outputName = nonEmptyOr(cfg.As, "count_all")
+		return r
+	}
+	num, label, ok := g.lookupSnapshotCol(cfg.SourceCol)
+	if !ok {
+		r.err = fmt.Sprintf("Aggregate: source column %q not found", cfg.SourceCol)
+		r.outputName = nonEmptyOr(cfg.As, fmt.Sprintf("%s_%s", cfg.SourceCol, cfg.Op))
+		return r
+	}
+	r.sourceNum = num
+	r.sourceCol = g.columnsSnapshot[num]
+	r.hasSource = true
+	r.outputName = nonEmptyOr(cfg.As, fmt.Sprintf("%s_%s", label, cfg.Op))
+	if cfg.Op == OpCustom && cfg.Custom == nil {
+		r.err = fmt.Sprintf("Aggregate: OpCustom requires Custom func for column %q", cfg.SourceCol)
+		return r
+	}
+	return r
+}
+
+// lookupSnapshotCol resolves a token against the snapshot taken at GroupBy
+// time, returning (colNumber, displayLabel, ok). Order: name first, then
+// Excel-style index.
+func (g *GroupedDataTable) lookupSnapshotCol(token string) (int, string, bool) {
+	for i, col := range g.columnsSnapshot {
+		if col.name == token {
+			return i, token, true
+		}
+	}
+	upper := strings.ToUpper(token)
+	if num, ok := utils.ParseColIndex(upper); ok {
+		if num >= 0 && num < len(g.columnsSnapshot) {
+			label := upper
+			if name := g.columnsSnapshot[num].name; name != "" {
+				label = name
+			}
+			return num, label, true
+		}
+	}
+	return 0, token, false
+}
+
+// computeAggregate runs a single aggregate over the rows belonging to a group.
+func (g *GroupedDataTable) computeAggregate(r aggregateResolved, rowIdxs []int) any {
+	if r.err != "" {
+		return nil
+	}
+	switch r.cfg.Op {
+	case OpCountAll:
+		return len(rowIdxs)
+	}
+	if !r.hasSource {
+		return nil
+	}
+	// Build a sub-DataList for the group from the source column. Preserve
+	// row order so OpFirst / OpLast and custom funcs see what the user
+	// expects.
+	sub := NewDataList()
+	for _, idx := range rowIdxs {
+		if idx < len(r.sourceCol.data) {
+			sub.Append(r.sourceCol.data[idx])
+		} else {
+			sub.Append(nil)
+		}
+	}
+	switch r.cfg.Op {
+	case OpSum:
+		return sub.Sum()
+	case OpMean:
+		return sub.Mean()
+	case OpMedian:
+		return sub.Median()
+	case OpMin:
+		return sub.Min()
+	case OpMax:
+		return sub.Max()
+	case OpStdev:
+		return sub.Stdev()
+	case OpStdevP:
+		return sub.StdevP()
+	case OpVar:
+		return sub.Var()
+	case OpVarP:
+		return sub.VarP()
+	case OpCount:
+		count := 0
+		for _, v := range sub.data {
+			if v != nil {
+				count++
+			}
+		}
+		return count
+	case OpFirst:
+		for _, v := range sub.data {
+			if v != nil {
+				return v
+			}
+		}
+		return nil
+	case OpLast:
+		for i := len(sub.data) - 1; i >= 0; i-- {
+			if sub.data[i] != nil {
+				return sub.data[i]
+			}
+		}
+		return nil
+	case OpNUnique:
+		return countUniqueNonNil(sub.data)
+	case OpCustom:
+		return r.cfg.Custom(sub)
+	}
+	return nil
+}
+
+// countUniqueNonNil counts distinct non-nil values. For values that are not
+// usable as map keys, falls back to a stringified representation.
+func countUniqueNonNil(values []any) int {
+	seen := map[string]struct{}{}
+	for _, v := range values {
+		if v == nil {
+			continue
+		}
+		key := uniqueKey(v)
+		seen[key] = struct{}{}
+	}
+	return len(seen)
+}
+
+func uniqueKey(v any) string {
+	switch tv := v.(type) {
+	case string:
+		return "s:" + tv
+	case bool:
+		if tv {
+			return "b:1"
+		}
+		return "b:0"
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("i:%v", v)
+	case float32, float64:
+		f, _ := utils.ToFloat64Safe(v)
+		if math.IsNaN(f) {
+			return "f:NaN"
+		}
+		return fmt.Sprintf("f:%v", f)
+	}
+	return fmt.Sprintf("o:%T:%v", v, v)
+}
+
+func nonEmptyOr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+

--- a/datatable_groupby_test.go
+++ b/datatable_groupby_test.go
@@ -1,0 +1,525 @@
+package insyra
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+// helper: build a DataTable with named columns from parallel slices.
+func buildSalesTable() *DataTable {
+	region := NewDataList("east", "east", "west", "west", "east", "south")
+	region.SetName("region")
+	product := NewDataList("a", "b", "a", "b", "a", "a")
+	product.SetName("product")
+	revenue := NewDataList(100, 200, 50, 75, 150, 300)
+	revenue.SetName("revenue")
+	qty := NewDataList(1, 2, 3, 4, 5, 6)
+	qty.SetName("qty")
+	status := NewDataList("ok", "ok", "ok", nil, "ok", "fail")
+	status.SetName("status")
+	dt := NewDataTable()
+	dt.AppendCols(region, product, revenue, qty, status)
+	return dt
+}
+
+func mustGetFloat(t *testing.T, dl *DataList, idx int) float64 {
+	t.Helper()
+	if dl == nil {
+		t.Fatalf("DataList is nil")
+	}
+	d := dl.Data()
+	if idx < 0 || idx >= len(d) {
+		t.Fatalf("index %d out of range (len=%d)", idx, len(d))
+	}
+	f, ok := ToFloat64Safe(d[idx])
+	if !ok {
+		t.Fatalf("value %v is not numeric", d[idx])
+	}
+	return f
+}
+
+func TestDataTable_GroupBy_SingleKey_MultiAgg(t *testing.T) {
+	dt := buildSalesTable()
+	out := dt.GroupBy("region").Aggregate(
+		AggregateConfig{SourceCol: "revenue", Op: OpSum, As: "total_rev"},
+		AggregateConfig{SourceCol: "revenue", Op: OpMean, As: "avg_rev"},
+		AggregateConfig{SourceCol: "qty", Op: OpSum, As: "total_qty"},
+		AggregateConfig{SourceCol: "status", Op: OpCount, As: "n_orders"},
+	)
+
+	if out.NumRows() != 3 {
+		t.Fatalf("expected 3 groups (east/west/south), got %d", out.NumRows())
+	}
+	if out.NumCols() != 5 {
+		t.Fatalf("expected 5 cols (region + 4 aggregates), got %d", out.NumCols())
+	}
+
+	got := []string{}
+	for _, v := range out.GetColByName("region").Data() {
+		got = append(got, v.(string))
+	}
+	expected := []string{"east", "west", "south"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("first-seen order broken: got %v want %v", got, expected)
+	}
+
+	totalRev := out.GetColByName("total_rev").Data()
+	if mustGetFloat(t, NewDataList(totalRev[0]), 0) != 450 {
+		t.Errorf("east total_rev = %v want 450", totalRev[0])
+	}
+	if mustGetFloat(t, NewDataList(totalRev[1]), 0) != 125 {
+		t.Errorf("west total_rev = %v want 125", totalRev[1])
+	}
+	if mustGetFloat(t, NewDataList(totalRev[2]), 0) != 300 {
+		t.Errorf("south total_rev = %v want 300", totalRev[2])
+	}
+
+	avgRev := out.GetColByName("avg_rev").Data()
+	if mustGetFloat(t, NewDataList(avgRev[0]), 0) != 150 {
+		t.Errorf("east avg_rev = %v want 150", avgRev[0])
+	}
+
+	nOrders := out.GetColByName("n_orders").Data()
+	// east: 3 non-nil; west: 1 non-nil (one nil); south: 1 non-nil.
+	if nOrders[0].(int) != 3 || nOrders[1].(int) != 1 || nOrders[2].(int) != 1 {
+		t.Errorf("n_orders = %v want [3 1 1]", nOrders)
+	}
+}
+
+func TestDataTable_GroupBy_MultiKey_AutoAlias(t *testing.T) {
+	dt := buildSalesTable()
+	out := dt.GroupBy("region", "product").Aggregate(
+		AggregateConfig{SourceCol: "revenue", Op: OpSum},
+		AggregateConfig{SourceCol: "qty", Op: OpMean},
+	)
+
+	if out.NumCols() != 4 {
+		t.Fatalf("expected 4 cols, got %d", out.NumCols())
+	}
+	headers := out.ColNames()
+	wantHeaders := []string{"region", "product", "revenue_sum", "qty_mean"}
+	if !reflect.DeepEqual(headers, wantHeaders) {
+		t.Fatalf("headers = %v want %v", headers, wantHeaders)
+	}
+
+	// Groups (in first-seen order):
+	// east+a, east+b, west+a, west+b, south+a => 5 groups.
+	if out.NumRows() != 5 {
+		t.Fatalf("expected 5 groups, got %d", out.NumRows())
+	}
+	regions := out.GetColByName("region").Data()
+	products := out.GetColByName("product").Data()
+	wantRegions := []any{"east", "east", "west", "west", "south"}
+	wantProducts := []any{"a", "b", "a", "b", "a"}
+	if !reflect.DeepEqual(regions, wantRegions) {
+		t.Errorf("regions = %v want %v", regions, wantRegions)
+	}
+	if !reflect.DeepEqual(products, wantProducts) {
+		t.Errorf("products = %v want %v", products, wantProducts)
+	}
+	revSum := out.GetColByName("revenue_sum").Data()
+	// east+a: 100+150=250, east+b: 200, west+a: 50, west+b: 75, south+a: 300.
+	want := []float64{250, 200, 50, 75, 300}
+	for i, v := range want {
+		if got := mustGetFloat(t, NewDataList(revSum[i]), 0); got != v {
+			t.Errorf("revenue_sum[%d] = %v want %v", i, got, v)
+		}
+	}
+}
+
+func TestDataTable_GroupBy_OpsCoverage(t *testing.T) {
+	dt := buildSalesTable()
+	out := dt.GroupBy("region").Aggregate(
+		AggregateConfig{SourceCol: "revenue", Op: OpMin, As: "rmin"},
+		AggregateConfig{SourceCol: "revenue", Op: OpMax, As: "rmax"},
+		AggregateConfig{SourceCol: "revenue", Op: OpMedian, As: "rmed"},
+		AggregateConfig{SourceCol: "revenue", Op: OpStdev, As: "rstd"},
+		AggregateConfig{SourceCol: "revenue", Op: OpStdevP, As: "rstdp"},
+		AggregateConfig{SourceCol: "revenue", Op: OpVar, As: "rvar"},
+		AggregateConfig{SourceCol: "revenue", Op: OpVarP, As: "rvarp"},
+		AggregateConfig{SourceCol: "status", Op: OpFirst, As: "first_status"},
+		AggregateConfig{SourceCol: "status", Op: OpLast, As: "last_status"},
+		AggregateConfig{SourceCol: "product", Op: OpNUnique, As: "n_products"},
+		AggregateConfig{Op: OpCountAll, As: "n_rows"},
+	)
+
+	rmin := out.GetColByName("rmin").Data()
+	rmax := out.GetColByName("rmax").Data()
+	rmed := out.GetColByName("rmed").Data()
+	if mustGetFloat(t, NewDataList(rmin[0]), 0) != 100 {
+		t.Errorf("east min = %v want 100", rmin[0])
+	}
+	if mustGetFloat(t, NewDataList(rmax[0]), 0) != 200 {
+		t.Errorf("east max = %v want 200", rmax[0])
+	}
+	if mustGetFloat(t, NewDataList(rmed[0]), 0) != 150 {
+		t.Errorf("east median = %v want 150", rmed[0])
+	}
+
+	// south has 1 element; sample stdev/var must be NaN.
+	rstd := out.GetColByName("rstd").Data()
+	rstdp := out.GetColByName("rstdp").Data()
+	rvar := out.GetColByName("rvar").Data()
+	rvarp := out.GetColByName("rvarp").Data()
+	if v, _ := ToFloat64Safe(rstd[2]); !math.IsNaN(v) {
+		t.Errorf("south stdev should be NaN got %v", v)
+	}
+	if v, _ := ToFloat64Safe(rstdp[2]); v != 0 {
+		t.Errorf("south stdevP should be 0 (single-element population), got %v", v)
+	}
+	if v, _ := ToFloat64Safe(rvar[2]); !math.IsNaN(v) {
+		t.Errorf("south var should be NaN got %v", v)
+	}
+	if v, _ := ToFloat64Safe(rvarp[2]); v != 0 {
+		t.Errorf("south varP should be 0 got %v", v)
+	}
+
+	firstStatus := out.GetColByName("first_status").Data()
+	lastStatus := out.GetColByName("last_status").Data()
+	// west has values [ok, nil] -> first=ok, last=ok (skipping the nil)
+	if firstStatus[1] != "ok" {
+		t.Errorf("west first_status = %v want ok", firstStatus[1])
+	}
+	if lastStatus[1] != "ok" {
+		t.Errorf("west last_status = %v want ok", lastStatus[1])
+	}
+
+	nProducts := out.GetColByName("n_products").Data()
+	// east has products a,b,a -> 2 unique
+	if nProducts[0].(int) != 2 {
+		t.Errorf("east n_products = %v want 2", nProducts[0])
+	}
+	if nProducts[2].(int) != 1 {
+		t.Errorf("south n_products = %v want 1", nProducts[2])
+	}
+
+	nRows := out.GetColByName("n_rows").Data()
+	wantRows := []int{3, 2, 1}
+	for i, w := range wantRows {
+		if nRows[i].(int) != w {
+			t.Errorf("n_rows[%d] = %v want %v", i, nRows[i], w)
+		}
+	}
+}
+
+func TestDataTable_GroupBy_Custom(t *testing.T) {
+	dt := buildSalesTable()
+	out := dt.GroupBy("region").Aggregate(
+		AggregateConfig{
+			SourceCol: "revenue",
+			As:        "rev_x_qty",
+			Op:        OpCustom,
+			Custom: func(group *DataList) any {
+				// Sum of squares of revenue, ignoring nil.
+				s := 0.0
+				for _, v := range group.Data() {
+					if v == nil {
+						continue
+					}
+					f, ok := ToFloat64Safe(v)
+					if !ok {
+						continue
+					}
+					s += f * f
+				}
+				return s
+			},
+		},
+	)
+	got := out.GetColByName("rev_x_qty").Data()
+	// east revenue [100,200,150]; sumsq = 10000+40000+22500 = 72500
+	if mustGetFloat(t, NewDataList(got[0]), 0) != 72500 {
+		t.Errorf("east sumsq = %v want 72500", got[0])
+	}
+	// west [50,75]; 2500+5625 = 8125
+	if mustGetFloat(t, NewDataList(got[1]), 0) != 8125 {
+		t.Errorf("west sumsq = %v want 8125", got[1])
+	}
+	// south [300]; 90000
+	if mustGetFloat(t, NewDataList(got[2]), 0) != 90000 {
+		t.Errorf("south sumsq = %v want 90000", got[2])
+	}
+}
+
+func TestDataTable_GroupBy_CustomNil_ReturnsEmpty(t *testing.T) {
+	dt := buildSalesTable()
+	dt.ClearErr()
+	out := dt.GroupBy("region").Aggregate(
+		AggregateConfig{SourceCol: "revenue", Op: OpCustom, As: "bad"},
+	)
+	if out.NumCols() == 0 {
+		t.Fatalf("expected key column to still be emitted")
+	}
+	bad := out.GetColByName("bad").Data()
+	for _, v := range bad {
+		if v != nil {
+			t.Errorf("bad column should be nil-filled when Custom is missing, got %v", v)
+		}
+	}
+	if dt.Err() == nil {
+		t.Errorf("expected parent DataTable to record an error when Custom is nil")
+	}
+}
+
+func TestDataTable_GroupBy_UnknownKey(t *testing.T) {
+	dt := buildSalesTable()
+	dt.ClearErr()
+	out := dt.GroupBy("nonexistent").Aggregate(
+		AggregateConfig{SourceCol: "revenue", Op: OpSum},
+	)
+	if out.NumRows() != 0 || out.NumCols() != 0 {
+		t.Fatalf("expected empty DataTable for unknown key, got %dx%d", out.NumRows(), out.NumCols())
+	}
+	if dt.Err() == nil {
+		t.Errorf("expected parent DataTable to record an error for unknown key")
+	}
+}
+
+func TestDataTable_GroupBy_UnknownSource(t *testing.T) {
+	dt := buildSalesTable()
+	dt.ClearErr()
+	out := dt.GroupBy("region").Aggregate(
+		AggregateConfig{SourceCol: "nope", Op: OpSum, As: "bad"},
+		AggregateConfig{SourceCol: "revenue", Op: OpSum, As: "good"},
+	)
+	if out.NumRows() != 3 {
+		t.Fatalf("expected 3 groups, got %d", out.NumRows())
+	}
+	bad := out.GetColByName("bad").Data()
+	for _, v := range bad {
+		if v != nil {
+			t.Errorf("bad column should be nil for unresolved source, got %v", v)
+		}
+	}
+	good := out.GetColByName("good").Data()
+	if mustGetFloat(t, NewDataList(good[0]), 0) != 450 {
+		t.Errorf("good column was contaminated by sibling failure")
+	}
+	if dt.Err() == nil {
+		t.Errorf("expected parent DataTable to flag the unresolved source col")
+	}
+}
+
+func TestDataTable_GroupBy_NilKeys(t *testing.T) {
+	a := NewDataList("x", nil, "x", nil)
+	a.SetName("k")
+	b := NewDataList(1, 2, 3, 4)
+	b.SetName("v")
+	dt := NewDataTable()
+	dt.AppendCols(a, b)
+	out := dt.GroupBy("k").Aggregate(
+		AggregateConfig{SourceCol: "v", Op: OpSum, As: "vs"},
+	)
+	if out.NumRows() != 2 {
+		t.Fatalf("nil should form its own group; expected 2 groups, got %d", out.NumRows())
+	}
+	keys := out.GetColByName("k").Data()
+	if keys[0] != "x" || keys[1] != nil {
+		t.Errorf("group keys preserve original typed values: got %v", keys)
+	}
+	vs := out.GetColByName("vs").Data()
+	if mustGetFloat(t, NewDataList(vs[0]), 0) != 4 {
+		t.Errorf("x sum = %v want 4", vs[0])
+	}
+	if mustGetFloat(t, NewDataList(vs[1]), 0) != 6 {
+		t.Errorf("nil-key sum = %v want 6", vs[1])
+	}
+}
+
+func TestDataTable_GroupBy_NumericVsStringKey(t *testing.T) {
+	// Strings "1" and integer 1 should not collide.
+	k := NewDataList(1, "1", 1, "1")
+	k.SetName("k")
+	v := NewDataList(10, 20, 30, 40)
+	v.SetName("v")
+	dt := NewDataTable()
+	dt.AppendCols(k, v)
+	out := dt.GroupBy("k").Aggregate(
+		AggregateConfig{SourceCol: "v", Op: OpSum, As: "vs"},
+	)
+	if out.NumRows() != 2 {
+		t.Fatalf("typed keys should distinguish int 1 from string \"1\", got %d groups", out.NumRows())
+	}
+	vs := out.GetColByName("vs").Data()
+	if mustGetFloat(t, NewDataList(vs[0]), 0) != 40 {
+		t.Errorf("int-key sum = %v want 40", vs[0])
+	}
+	if mustGetFloat(t, NewDataList(vs[1]), 0) != 60 {
+		t.Errorf("string-key sum = %v want 60", vs[1])
+	}
+}
+
+func TestDataTable_GroupBy_EmptyTable(t *testing.T) {
+	dt := NewDataTable()
+	dt.AppendCols(NewDataList().SetName("k"), NewDataList().SetName("v"))
+	out := dt.GroupBy("k").Aggregate(
+		AggregateConfig{SourceCol: "v", Op: OpSum, As: "vs"},
+	)
+	if out.NumRows() != 0 {
+		t.Fatalf("empty table should produce zero groups, got %d", out.NumRows())
+	}
+	if out.NumCols() != 2 {
+		t.Fatalf("expected key + agg columns, got %d", out.NumCols())
+	}
+}
+
+func TestDataTable_GroupBy_SingleRow(t *testing.T) {
+	k := NewDataList("only")
+	k.SetName("k")
+	v := NewDataList(42)
+	v.SetName("v")
+	dt := NewDataTable()
+	dt.AppendCols(k, v)
+	out := dt.GroupBy("k").Aggregate(
+		AggregateConfig{SourceCol: "v", Op: OpSum, As: "vs"},
+	)
+	if out.NumRows() != 1 {
+		t.Fatalf("expected 1 group, got %d", out.NumRows())
+	}
+	if mustGetFloat(t, out.GetColByName("vs"), 0) != 42 {
+		t.Errorf("single-row sum incorrect")
+	}
+}
+
+func TestDataTable_GroupBy_SingleGroupAllRows(t *testing.T) {
+	k := NewDataList("same", "same", "same")
+	k.SetName("k")
+	v := NewDataList(1, 2, 3)
+	v.SetName("v")
+	dt := NewDataTable()
+	dt.AppendCols(k, v)
+	out := dt.GroupBy("k").Aggregate(
+		AggregateConfig{SourceCol: "v", Op: OpSum, As: "vs"},
+		AggregateConfig{SourceCol: "v", Op: OpMean, As: "vm"},
+	)
+	if out.NumRows() != 1 {
+		t.Fatalf("expected 1 group, got %d", out.NumRows())
+	}
+	if mustGetFloat(t, out.GetColByName("vs"), 0) != 6 {
+		t.Errorf("sum should be 6")
+	}
+	if mustGetFloat(t, out.GetColByName("vm"), 0) != 2 {
+		t.Errorf("mean should be 2")
+	}
+}
+
+func TestDataTable_GroupBy_KeyByExcelIndex(t *testing.T) {
+	dt := buildSalesTable() // region is column A
+	out := dt.GroupBy("A").Aggregate(
+		AggregateConfig{SourceCol: "C", Op: OpSum, As: "rev_sum"},
+	)
+	if out.NumRows() != 3 {
+		t.Fatalf("expected 3 groups, got %d", out.NumRows())
+	}
+	got := out.GetColByName("rev_sum").Data()
+	if mustGetFloat(t, NewDataList(got[0]), 0) != 450 {
+		t.Errorf("east rev_sum = %v want 450", got[0])
+	}
+}
+
+func TestDataTable_GroupBy_AggregateAll(t *testing.T) {
+	dt := buildSalesTable()
+	out := dt.GroupBy("region").AggregateAll(OpSum)
+	headers := out.ColNames()
+	// region + every non-key column
+	want := []string{"region", "product_sum", "revenue_sum", "qty_sum", "status_sum"}
+	if !reflect.DeepEqual(headers, want) {
+		t.Fatalf("headers = %v want %v", headers, want)
+	}
+	revSum := out.GetColByName("revenue_sum").Data()
+	if mustGetFloat(t, NewDataList(revSum[0]), 0) != 450 {
+		t.Errorf("east revenue_sum = %v want 450", revSum[0])
+	}
+}
+
+func TestDataTable_GroupBy_AggregateAll_RejectsCustom(t *testing.T) {
+	dt := buildSalesTable()
+	dt.ClearErr()
+	out := dt.GroupBy("region").AggregateAll(OpCustom)
+	if out.NumRows() != 0 {
+		t.Errorf("AggregateAll(OpCustom) should return empty table")
+	}
+	if dt.Err() == nil {
+		t.Errorf("expected parent error for AggregateAll(OpCustom)")
+	}
+}
+
+func TestDataTable_GroupBy_Count(t *testing.T) {
+	dt := buildSalesTable()
+	out := dt.GroupBy("region").Count()
+	if out.NumCols() != 2 {
+		t.Fatalf("expected region + count, got %d cols", out.NumCols())
+	}
+	count := out.GetColByName("count").Data()
+	want := []int{3, 2, 1}
+	for i, w := range want {
+		if count[i].(int) != w {
+			t.Errorf("count[%d] = %v want %v", i, count[i], w)
+		}
+	}
+}
+
+func TestDataTable_GroupBy_NoConfigs(t *testing.T) {
+	dt := buildSalesTable()
+	dt.ClearErr()
+	out := dt.GroupBy("region").Aggregate()
+	if out.NumRows() != 0 || out.NumCols() != 0 {
+		t.Fatalf("expected empty table when no configs, got %dx%d", out.NumRows(), out.NumCols())
+	}
+	if dt.Err() == nil {
+		t.Errorf("expected parent error when no configs are passed")
+	}
+}
+
+func TestDataTable_GroupBy_NoKeys(t *testing.T) {
+	dt := buildSalesTable()
+	dt.ClearErr()
+	out := dt.GroupBy().Aggregate(AggregateConfig{SourceCol: "revenue", Op: OpSum})
+	if out.NumRows() != 0 || out.NumCols() != 0 {
+		t.Fatalf("expected empty table when no keys, got %dx%d", out.NumRows(), out.NumCols())
+	}
+	if dt.Err() == nil {
+		t.Errorf("expected parent error when no keys are passed")
+	}
+}
+
+func TestDataTable_GroupBy_PipelineWithSortBy(t *testing.T) {
+	dt := buildSalesTable()
+	out := dt.GroupBy("region").Aggregate(
+		AggregateConfig{SourceCol: "revenue", Op: OpSum, As: "total_rev"},
+	)
+	out.SortBy(DataTableSortConfig{ColumnName: "total_rev", Descending: true})
+	regions := out.GetColByName("region").Data()
+	if regions[0] != "east" {
+		t.Errorf("after sort, top region should be east (450), got %v", regions[0])
+	}
+	if regions[2] != "west" {
+		t.Errorf("after sort, bottom region should be west (125), got %v", regions[2])
+	}
+}
+
+func TestAggregateOp_String(t *testing.T) {
+	cases := map[AggregateOp]string{
+		OpSum:      "sum",
+		OpMean:     "mean",
+		OpMedian:   "median",
+		OpMin:      "min",
+		OpMax:      "max",
+		OpCount:    "count",
+		OpCountAll: "countall",
+		OpStdev:    "stdev",
+		OpStdevP:   "stdevp",
+		OpVar:      "var",
+		OpVarP:     "varp",
+		OpFirst:    "first",
+		OpLast:     "last",
+		OpNUnique:  "nunique",
+		OpCustom:   "custom",
+	}
+	for op, want := range cases {
+		if got := op.String(); got != want {
+			t.Errorf("op %d -> %q want %q", int(op), got, want)
+		}
+	}
+}

--- a/isr/groupby.go
+++ b/isr/groupby.go
@@ -1,0 +1,14 @@
+package isr
+
+import "github.com/HazelnutParadise/insyra"
+
+// GroupBy returns a *insyra.GroupedDataTable for the underlying DataTable,
+// matching the chain pattern of the rest of the isr package. Use it together
+// with insyra.AggregateConfig to do split-apply-combine:
+//
+//	report := dt.GroupBy("region").Aggregate(
+//	    insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpSum},
+//	)
+func (t *dt) GroupBy(keyCols ...string) *insyra.GroupedDataTable {
+	return t.DataTable.GroupBy(keyCols...)
+}

--- a/isr/groupby_test.go
+++ b/isr/groupby_test.go
@@ -1,0 +1,40 @@
+package isr_test
+
+import (
+	"testing"
+
+	"github.com/HazelnutParadise/insyra"
+	. "github.com/HazelnutParadise/insyra/isr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDT_GroupBy_Aggregate(t *testing.T) {
+	dt := DT.From(
+		DLs{
+			DL.From("east", "east", "west", "west", "south").SetName("region"),
+			DL.From(100, 200, 50, 75, 300).SetName("revenue"),
+			DL.From(1, 2, 3, 4, 5).SetName("qty"),
+		},
+	)
+
+	report := dt.GroupBy("region").Aggregate(
+		insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpSum, As: "total_rev"},
+		insyra.AggregateConfig{SourceCol: "qty", Op: insyra.OpMean, As: "avg_qty"},
+	)
+
+	assert.Equal(t, 3, report.NumRows(), "expected 3 groups")
+	assert.Equal(t, []string{"region", "total_rev", "avg_qty"}, report.ColNames(), "column order")
+
+	regions := report.GetColByName("region").Data()
+	assert.Equal(t, []any{"east", "west", "south"}, regions, "first-seen group order")
+
+	rev := report.GetColByName("total_rev").Data()
+	assert.InDelta(t, 300.0, rev[0], 1e-9)
+	assert.InDelta(t, 125.0, rev[1], 1e-9)
+	assert.InDelta(t, 300.0, rev[2], 1e-9)
+
+	avgQty := report.GetColByName("avg_qty").Data()
+	assert.InDelta(t, 1.5, avgQty[0], 1e-9)
+	assert.InDelta(t, 3.5, avgQty[1], 1e-9)
+	assert.InDelta(t, 5.0, avgQty[2], 1e-9)
+}

--- a/skills/insyra/SKILL.md
+++ b/skills/insyra/SKILL.md
@@ -199,6 +199,43 @@ dt.ExecuteCCL("NEW('FirstRowData') = @.0")
 ```
 
 
+### 3c) GroupBy + Aggregate (split-apply-combine)
+
+For "summarize by key" tasks (RFM segments, sales reports, per-bucket stats), use `DataTable.GroupBy(...)` followed by `Aggregate(...)`. Each `AggregateConfig` describes one output column; key columns appear first in the result, followed by aggregates in config order. Use `OpCustom` with `Custom func(group *DataList) any` for anything not covered by the built-in ops.
+
+```go
+import "github.com/HazelnutParadise/insyra"
+
+dt := /* DataTable with columns region, product, revenue, qty, status */
+
+report := dt.GroupBy("region").Aggregate(
+    insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpSum,   As: "total_rev"},
+    insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpMean,  As: "avg_rev"},
+    insyra.AggregateConfig{SourceCol: "qty",     Op: insyra.OpSum,   As: "total_qty"},
+    insyra.AggregateConfig{SourceCol: "status",  Op: insyra.OpCount, As: "n_orders"},
+)
+
+// Multi-key (auto-named output columns)
+quarterly := dt.GroupBy("region", "product").Aggregate(
+    insyra.AggregateConfig{SourceCol: "revenue", Op: insyra.OpSum},  // -> "revenue_sum"
+    insyra.AggregateConfig{SourceCol: "qty",     Op: insyra.OpMean}, // -> "qty_mean"
+)
+
+// Custom aggregate
+weighted := dt.GroupBy("region").Aggregate(
+    insyra.AggregateConfig{
+        SourceCol: "price",
+        As:        "wprice",
+        Op:        insyra.OpCustom,
+        Custom: func(group *insyra.DataList) any {
+            return group.Mean()
+        },
+    },
+)
+```
+
+Supported `AggregateOp`: `OpSum`, `OpMean`, `OpMedian`, `OpMin`, `OpMax`, `OpCount` (non-nil), `OpCountAll` (group size), `OpStdev`, `OpStdevP`, `OpVar`, `OpVarP`, `OpFirst`, `OpLast`, `OpNUnique`, `OpCustom`. Group order in the result follows the order each key combination is first seen during a single linear scan; `nil` keys form their own group, and `int(1)` and string `"1"` are kept distinct.
+
 ### 4) Export a DataTable to CSV
 
 ```go

--- a/skills/use-insyra-cli/SKILL.md
+++ b/skills/use-insyra-cli/SKILL.md
@@ -141,7 +141,16 @@ insyra env import ./exp1.json exp1-copy --force
 
 # Run script in environment
 insyra --env exp1 run ./pipeline.isr
+
+# Group rows by key, aggregate columns (split-apply-combine)
+insyra load sales.csv as sales
+insyra groupby sales by region agg revenue:sum:total_rev qty:mean as report
+insyra show report
+# Multi-key + count shorthand
+insyra groupby sales by region,product agg revenue:sum count as report2
 ```
+
+`groupby <var> by <col1>[,<col2>...] agg <col>:<op>[:<alias>] [<col>:<op>[:<alias>] ...] [as <var>]` produces a new DataTable with one row per unique key combination. Supported ops: `sum`, `mean` (alias `avg`), `median`, `min`, `max`, `count` (non-nil), `countall` (group size), `std`/`stdev`, `stdp`/`stdevp`, `var`, `varp`, `first`, `last`, `nunique`. The bare token `count` is shorthand for `:countall:count`.
 
 ## Reference priority for agents
 

--- a/skills/use-insyra-cli/references/cli-command-guide.md
+++ b/skills/use-insyra-cli/references/cli-command-guide.md
@@ -223,6 +223,13 @@ Generated from current command registry (`insyra help`, `insyra help <command>`)
 - Usage: `merge <var1> <var2> <direction> <mode> [on <cols>] [as <var>]`
 - Example: `insyra merge x1 x2 inner strict`
 
+### `groupby`
+- Description: Group a DataTable and aggregate columns (split-apply-combine)
+- Usage: `groupby <var> by <col1>[,<col2>...] agg <col>:<op>[:<alias>] [<col>:<op>[:<alias>] ...] [as <var>]`
+- Example: `insyra groupby sales by region agg revenue:sum:total_rev qty:mean as report`
+- Multi-key with row-count shorthand: `insyra groupby sales by region,product agg revenue:sum count as report2`
+- Ops: `sum`, `mean` (alias `avg`), `median`, `min`, `max`, `count` (non-nil), `countall` (group size), `std`/`stdev`, `stdp`/`stdevp`, `var`, `varp`, `first`, `last`, `nunique`. Aliases default to `<col>_<op>`.
+
 ### `ccl`
 - Description: Execute CCL statements on DataTable
 - Usage: `ccl <var> <expression>`

--- a/skills/use-insyra-cli/references/cli-command-usage.md
+++ b/skills/use-insyra-cli/references/cli-command-usage.md
@@ -146,6 +146,16 @@ For expanded subcommand forms and practical examples, see `cli-command-guide.md`
 - Description: Get single element from DataTable
 - Usage: `get <var> <row> <col>`
 
+## `groupby`
+- Description: Group a DataTable and aggregate columns
+- Usage: `groupby <var> by <col1>[,<col2>...] agg <col>:<op>[:<alias>] [<col>:<op>[:<alias>] ...] [as <var>]`
+- Notes:
+  - Ops: `sum`, `mean` (alias `avg`), `median`, `min`, `max`, `count` (non-nil), `countall` (group size), `std`/`stdev`, `stdp`/`stdevp`, `var`, `varp`, `first`, `last`, `nunique`.
+  - Bare token `count` is shorthand for `:countall:count`.
+  - Aliases default to `<col>_<op>`.
+  - Output column order: keys first (in `by` order), then aggregates (in `agg` order).
+  - Group order: each unique key combination in first-seen order.
+
 ## `help`
 - Description: Show command help
 - Usage: `help [command]`

--- a/skills/use-insyra-cli/references/cli-commands.md
+++ b/skills/use-insyra-cli/references/cli-commands.md
@@ -63,6 +63,7 @@ This list is generated from `insyra help` in this repository state.
 - `replace` - Replace values in DataTable/DataList
 - `clean` - Clean values from DataTable/DataList
 - `merge` - Merge two DataTables
+- `groupby` - Group a DataTable and aggregate columns (split-apply-combine)
 - `ccl` - Execute CCL statements on DataTable
 - `addcolccl` - Add DataTable column using CCL
 


### PR DESCRIPTION
## Summary

Closes #156. Adds GroupBy / Aggregate to DataTable so callers can do split-apply-combine without hand-rolled `Filter` + `GetCol` + `Sum` loops.

- `DataTable.GroupBy(keyCols ...string) *GroupedDataTable`
- `(*GroupedDataTable).Aggregate(configs ...AggregateConfig) *DataTable` — plus `AggregateAll(op)` and `Count()` sugar
- 15 `AggregateOp`: `Sum`, `Mean`, `Median`, `Min`, `Max`, `Count` (non-nil), `CountAll` (group size), `Stdev`, `StdevP`, `Var`, `VarP`, `First`, `Last`, `NUnique`, `Custom`
- `isr` wrapper: `(*dt).GroupBy(...)` returns `*insyra.GroupedDataTable`
- New CLI command: `groupby <var> by <col1>[,<col2>...] agg <col>:<op>[:<alias>] [...] [as <var>]` (also accepts `count` as shorthand for `:countall:count`, plus aliases like `avg`/`std`/`stdp`)

### Behaviour notes

- Single linear O(N) scan over rows; aggregates per group reuse existing `DataList.Sum/Mean/...` (no reinvented stats).
- Group order: first-seen order of each unique key combination.
- `nil` keys form their own group; typed encoding keeps `int(1)` distinct from string `"1"`.
- Unknown key/source columns and missing `Custom` for `OpCustom` are surfaced through the existing `dt.Err()` instance-level error pattern; the result is still returned (with affected columns nil-filled), so chains keep flowing.
- Snapshots column refs inside `AtomicDo`, then runs `Aggregate` outside the lock — matches the existing actor-model conventions.

### Tests / verification

- 22 new unit tests in `datatable_groupby_test.go` covering: single/multi key, every Op, Excel-index keys, nil keys, type-distinct keys, empty / single-row / single-group degenerate cases, custom-func happy and error paths, sibling-config isolation when one source col is unknown, `SortBy` chaining.
- `isr/groupby_test.go` — public-API integration test.
- `cli/commands/groupby_test.go` — CLI parsing, multi-key, count shorthand, error paths.
- `go test ./...` passes locally.
- `golangci-lint run ./...` reports 0 issues.
- End-to-end CLI smoke test (REPL + `.isr` script) produces correct values on a sales dataset.

### Docs / skills

- `Docs/DataTable.md` — new `GroupBy` section under Data Operations.
- `Docs/isr.md` — wrapper documented under DataTable Methods.
- `Docs/cli-dsl.md` — quickstart example + appendix entry.
- `skills/insyra/SKILL.md`, `skills/use-insyra-cli/SKILL.md`, plus the three CLI references — all updated with examples.

## Test plan

- [x] `go test ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] CLI / REPL smoke test against named columns
- [ ] Reviewer: spot-check output ordering and `nil`-key handling matches the issue spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)