### PR TITLE
feat(cli/env): refactor to Manager type for per-session env storage (#160)

### DIFF
--- a/Docs/cli-dsl.md
+++ b/Docs/cli-dsl.md
@@ -90,11 +90,12 @@ package main
 import (
     "fmt"
 
+    "github.com/HazelnutParadise/insyra/cli/env"
     "github.com/HazelnutParadise/insyra/engine/dsl"
 )
 
 func main() {
-    session, err := dsl.NewSession("default", nil)
+    session, err := dsl.NewSession(env.Default(), "default", nil)
     if err != nil {
         panic(err)
     }
@@ -111,6 +112,48 @@ func main() {
 ```
 
 `Execute` accepts the same DSL syntax as REPL and `.isr`.
+
+#### Custom environment storage location
+
+`NewSession` takes an `*env.Manager` that owns where environment files live.
+Pass `env.Default()` for the standard `<UserHomeDir>/.insyra/envs/` layout,
+or `env.NewManager(basePath, envsDirName)` for a custom root and/or a
+custom per-environment subfolder name:
+
+```go
+// /workspace/.idensyra/envs/<name>/
+mgr := env.NewManager("/workspace/.idensyra", "")
+
+// /workspace/.idensyra/insights/<name>/  (Idensyra's layout)
+mgr := env.NewManager("/workspace/.idensyra", "insights")
+
+session, err := dsl.NewSession(mgr, "default", &out)
+```
+
+Both arguments accept "" to fall back to the defaults
+(`<UserHomeDir>/.insyra` and `"envs"`).
+
+Each session keeps its own Manager, so multiple sessions can coexist in
+the same process with different roots and not interfere:
+
+```go
+mgrA := env.NewManager("/wsA", "")
+mgrB := env.NewManager("/wsB", "")
+
+sessionA, _ := dsl.NewSession(mgrA, "default", outA)
+sessionB, _ := dsl.NewSession(mgrB, "default", outB)
+// sessionA reads/writes /wsA/envs/...; sessionB reads/writes /wsB/envs/...
+```
+
+The Manager is also useful on its own when you only need the storage layer
+(listing envs, exporting, reading history) without spinning up a session:
+
+```go
+mgr := env.NewManager("/workspace/.idensyra", "insights")
+envs, _ := mgr.List()
+mgr.Create("scratch")
+mgr.Export("scratch", "/tmp/backup.json")
+```
 
 ## Global Flags
 
@@ -323,13 +366,14 @@ import (
     "bytes"
     "fmt"
 
+    "github.com/HazelnutParadise/insyra/cli/env"
     "github.com/HazelnutParadise/insyra/engine/dsl"
 )
 
 func main() {
     var out bytes.Buffer
 
-    session, err := dsl.NewSession("demo", &out)
+    session, err := dsl.NewSession(env.Default(), "demo", &out)
     if err != nil {
         panic(err)
     }

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/HazelnutParadise/insyra/cli/env"
 )
 
 func init() {
@@ -18,7 +16,7 @@ func init() {
 
 func runConfigCommand(ctx *ExecContext, args []string) error {
 	if len(args) == 0 {
-		cfg, err := env.LoadGlobalConfig()
+		cfg, err := ctx.Env.LoadGlobalConfig()
 		if err != nil {
 			return err
 		}
@@ -34,7 +32,7 @@ func runConfigCommand(ctx *ExecContext, args []string) error {
 		return fmt.Errorf("usage: config [key] [value]")
 	}
 
-	cfg, err := env.UpdateGlobalConfig(args[0], args[1])
+	cfg, err := ctx.Env.UpdateGlobalConfig(args[0], args[1])
 	if err != nil {
 		return err
 	}

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/HazelnutParadise/insyra/cli/env"
 )
 
 func init() {
@@ -28,13 +26,13 @@ func runEnvCommand(ctx *ExecContext, args []string) error {
 		if len(args) < 2 {
 			return fmt.Errorf("usage: env create <name>")
 		}
-		if err := env.Create(args[1]); err != nil {
+		if err := ctx.Env.Create(args[1]); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(ctx.Output, "created environment: %s\n", args[1])
 		return nil
 	case "list":
-		items, err := env.List()
+		items, err := ctx.Env.List()
 		if err != nil {
 			return err
 		}
@@ -58,13 +56,13 @@ func runEnvCommand(ctx *ExecContext, args []string) error {
 		if len(args) < 2 {
 			return fmt.Errorf("usage: env open <name>")
 		}
-		envPath, err := env.Open(args[1])
+		envPath, err := ctx.Env.Open(args[1])
 		if err != nil {
 			return err
 		}
 		ctx.EnvName = args[1]
 		ctx.EnvPath = envPath
-		vars, err := env.RestoreVariables(args[1])
+		vars, err := ctx.Env.RestoreVariables(args[1])
 		if err == nil {
 			ctx.Vars = vars
 		}
@@ -78,7 +76,7 @@ func runEnvCommand(ctx *ExecContext, args []string) error {
 		if err != nil {
 			return err
 		}
-		if err := env.Clear(name, keepHistory); err != nil {
+		if err := ctx.Env.Clear(name, keepHistory); err != nil {
 			return err
 		}
 		if name == ctx.EnvName {
@@ -95,7 +93,7 @@ func runEnvCommand(ctx *ExecContext, args []string) error {
 		if err != nil {
 			return err
 		}
-		if err := env.Export(name, out); err != nil {
+		if err := ctx.Env.Export(name, out); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(ctx.Output, "exported environment %s -> %s\n", name, out)
@@ -105,12 +103,12 @@ func runEnvCommand(ctx *ExecContext, args []string) error {
 		if err != nil {
 			return err
 		}
-		name, err := env.Import(in, target, force)
+		name, err := ctx.Env.Import(in, target, force)
 		if err != nil {
 			return err
 		}
 		if name == ctx.EnvName {
-			vars, restoreErr := env.RestoreVariables(name)
+			vars, restoreErr := ctx.Env.RestoreVariables(name)
 			if restoreErr == nil {
 				ctx.Vars = vars
 			}
@@ -124,7 +122,7 @@ func runEnvCommand(ctx *ExecContext, args []string) error {
 		if args[1] == ctx.EnvName {
 			return fmt.Errorf("cannot delete current environment: %s", args[1])
 		}
-		if err := env.Delete(args[1]); err != nil {
+		if err := ctx.Env.Delete(args[1]); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(ctx.Output, "deleted environment: %s\n", args[1])
@@ -133,12 +131,12 @@ func runEnvCommand(ctx *ExecContext, args []string) error {
 		if len(args) < 3 {
 			return fmt.Errorf("usage: env rename <old> <new>")
 		}
-		if err := env.Rename(args[1], args[2]); err != nil {
+		if err := ctx.Env.Rename(args[1], args[2]); err != nil {
 			return err
 		}
 		if ctx.EnvName == args[1] {
 			ctx.EnvName = args[2]
-			if envPath, err := env.ResolveEnvPath(args[2]); err == nil {
+			if envPath, err := ctx.Env.ResolveEnvPath(args[2]); err == nil {
 				ctx.EnvPath = envPath
 			}
 		}
@@ -152,7 +150,7 @@ func runEnvCommand(ctx *ExecContext, args []string) error {
 		if name == "" {
 			name = "default"
 		}
-		item, err := env.Info(name)
+		item, err := ctx.Env.Info(name)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/history.go
+++ b/cli/commands/history.go
@@ -2,8 +2,6 @@ package commands
 
 import (
 	"fmt"
-
-	"github.com/HazelnutParadise/insyra/cli/env"
 )
 
 func init() {
@@ -19,7 +17,7 @@ func runHistoryCommand(ctx *ExecContext, args []string) error {
 	if ctx.EnvName == "" {
 		ctx.EnvName = "default"
 	}
-	entries, err := env.ReadHistory(ctx.EnvName)
+	entries, err := ctx.Env.ReadHistory(ctx.EnvName)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/registry.go
+++ b/cli/commands/registry.go
@@ -19,6 +19,11 @@ type ExecContext struct {
 	Output   io.Writer
 	InREPL   bool
 	OpenREPL func(ctx *ExecContext) error
+	// Env is the per-session environment Manager. Commands MUST go through
+	// it (ctx.Env.SaveState etc.) so embedders that supply a per-workspace
+	// Manager don't get their writes redirected to the default ~/.insyra.
+	// Dispatch fills this with env.Default() if the caller left it nil.
+	Env *env.Manager
 }
 
 type CommandHandler struct {
@@ -72,6 +77,9 @@ func Dispatch(ctx *ExecContext, name string, args []string) error {
 	if ctx.Output == nil {
 		ctx.Output = os.Stdout
 	}
+	if ctx.Env == nil {
+		ctx.Env = env.Default()
+	}
 	return handler.Run(ctx, args)
 }
 
@@ -121,7 +129,11 @@ func BuildCobraCommands(ctx *ExecContext) []*cobra.Command {
 					if len(runArgs) > 0 {
 						line += " " + strings.Join(runArgs, " ")
 					}
-					_ = env.AppendHistory(envName, line)
+					mgr := ctx.Env
+					if mgr == nil {
+						mgr = env.Default()
+					}
+					_ = mgr.AppendHistory(envName, line)
 				}
 				return err
 			},

--- a/cli/env/config.go
+++ b/cli/env/config.go
@@ -20,26 +20,26 @@ func defaultGlobalConfig() GlobalConfig {
 	}
 }
 
-func GlobalConfigPath() (string, error) {
-	base, err := BasePath()
+func (m *Manager) GlobalConfigPath() (string, error) {
+	base, err := m.BasePath()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(base, "config.json"), nil
 }
 
-func LoadGlobalConfig() (GlobalConfig, error) {
-	if err := EnsureBaseStructure(); err != nil {
+func (m *Manager) LoadGlobalConfig() (GlobalConfig, error) {
+	if err := m.EnsureBaseStructure(); err != nil {
 		return GlobalConfig{}, err
 	}
-	path, err := GlobalConfigPath()
+	path, err := m.GlobalConfigPath()
 	if err != nil {
 		return GlobalConfig{}, err
 	}
 	_, statErr := os.Stat(path)
 	if os.IsNotExist(statErr) {
 		cfg := defaultGlobalConfig()
-		if saveErr := SaveGlobalConfig(cfg); saveErr != nil {
+		if saveErr := m.SaveGlobalConfig(cfg); saveErr != nil {
 			return GlobalConfig{}, saveErr
 		}
 		return cfg, nil
@@ -50,7 +50,7 @@ func LoadGlobalConfig() (GlobalConfig, error) {
 	}
 	if len(bytes) == 0 {
 		cfg := defaultGlobalConfig()
-		if saveErr := SaveGlobalConfig(cfg); saveErr != nil {
+		if saveErr := m.SaveGlobalConfig(cfg); saveErr != nil {
 			return GlobalConfig{}, saveErr
 		}
 		return cfg, nil
@@ -62,11 +62,11 @@ func LoadGlobalConfig() (GlobalConfig, error) {
 	return cfg, nil
 }
 
-func SaveGlobalConfig(cfg GlobalConfig) error {
-	if err := EnsureBaseStructure(); err != nil {
+func (m *Manager) SaveGlobalConfig(cfg GlobalConfig) error {
+	if err := m.EnsureBaseStructure(); err != nil {
 		return err
 	}
-	path, err := GlobalConfigPath()
+	path, err := m.GlobalConfigPath()
 	if err != nil {
 		return err
 	}
@@ -77,8 +77,8 @@ func SaveGlobalConfig(cfg GlobalConfig) error {
 	return os.WriteFile(path, payload, 0o644)
 }
 
-func UpdateGlobalConfig(key, value string) (GlobalConfig, error) {
-	cfg, err := LoadGlobalConfig()
+func (m *Manager) UpdateGlobalConfig(key, value string) (GlobalConfig, error) {
+	cfg, err := m.LoadGlobalConfig()
 	if err != nil {
 		return GlobalConfig{}, err
 	}
@@ -90,8 +90,20 @@ func UpdateGlobalConfig(key, value string) (GlobalConfig, error) {
 	case "no-color", "noColor":
 		cfg.NoColor = value == "true" || value == "1" || value == "yes"
 	}
-	if err := SaveGlobalConfig(cfg); err != nil {
+	if err := m.SaveGlobalConfig(cfg); err != nil {
 		return GlobalConfig{}, err
 	}
 	return cfg, nil
+}
+
+// Package-level wrappers around the default Manager.
+
+func GlobalConfigPath() (string, error) { return defaultManager.GlobalConfigPath() }
+
+func LoadGlobalConfig() (GlobalConfig, error) { return defaultManager.LoadGlobalConfig() }
+
+func SaveGlobalConfig(cfg GlobalConfig) error { return defaultManager.SaveGlobalConfig(cfg) }
+
+func UpdateGlobalConfig(key, value string) (GlobalConfig, error) {
+	return defaultManager.UpdateGlobalConfig(key, value)
 }

--- a/cli/env/manager.go
+++ b/cli/env/manager.go
@@ -8,12 +8,13 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
 const (
-	baseDirName = ".insyra"
-	envsDirName = "envs"
+	baseDirName        = ".insyra"
+	defaultEnvsDirName = "envs"
 )
 
 type EnvironmentInfo struct {
@@ -32,7 +33,75 @@ type ExportPayload struct {
 	Config        json.RawMessage `json:"config"`
 }
 
-func BasePath() (string, error) {
+// Manager owns a single environment-storage root and exposes all
+// env-related operations (CRUD, state, history, config) as methods.
+//
+// Embedders that want per-workspace isolation should construct one Manager
+// per workspace via NewManager. The CLI binary and any code calling the
+// package-level wrapper functions share a single process-wide Default()
+// Manager rooted at <UserHomeDir>/.insyra/envs (overridable via SetBasePath
+// and SetEnvsDirName).
+type Manager struct {
+	mu          sync.RWMutex
+	basePath    string // empty = use UserHomeDir/.insyra
+	envsDirName string // empty = "envs"
+}
+
+// NewManager constructs a Manager rooted at basePath. envsDirName overrides
+// the per-environment subfolder name; pass "" for the default "envs".
+//
+// Examples:
+//
+//	env.NewManager("", "")                       // ~/.insyra/envs/<name>/
+//	env.NewManager("/ws/.idensyra", "")          // /ws/.idensyra/envs/<name>/
+//	env.NewManager("/ws/.idensyra", "insights")  // /ws/.idensyra/insights/<name>/
+//
+// Both fields are fixed at construction; create a new Manager to point
+// somewhere else.
+func NewManager(basePath, envsDirName string) *Manager {
+	return &Manager{
+		basePath:    strings.TrimSpace(basePath),
+		envsDirName: strings.TrimSpace(envsDirName),
+	}
+}
+
+var defaultManager = &Manager{}
+
+// Default returns the shared process-wide Manager used by the package-level
+// wrapper functions (env.BasePath, env.Create, …) and by SetBasePath.
+func Default() *Manager { return defaultManager }
+
+// SetBasePath overrides the default Manager's root. Pass "" to restore the
+// default <UserHomeDir>/.insyra. This only affects the package-level
+// wrappers and any caller that explicitly uses Default(); per-session
+// Managers created via NewManager are unaffected.
+func SetBasePath(path string) { defaultManager.SetBasePath(path) }
+
+// SetBasePath updates this Manager's root. Pass "" to fall back to the
+// default <UserHomeDir>/.insyra. Safe to call before opening or creating
+// any environment; not safe to change while an environment is in use.
+func (m *Manager) SetBasePath(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.basePath = strings.TrimSpace(path)
+}
+
+// SetEnvsDirName updates this Manager's per-environment subfolder name.
+// Pass "" to fall back to the default "envs". Same usage caveats as
+// SetBasePath — not safe to change while an environment is in use.
+func (m *Manager) SetEnvsDirName(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.envsDirName = strings.TrimSpace(name)
+}
+
+func (m *Manager) BasePath() (string, error) {
+	m.mu.RLock()
+	bp := m.basePath
+	m.mu.RUnlock()
+	if bp != "" {
+		return bp, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -40,43 +109,53 @@ func BasePath() (string, error) {
 	return filepath.Join(home, baseDirName), nil
 }
 
-func EnvsPath() (string, error) {
-	base, err := BasePath()
+func (m *Manager) EnvsDirName() string {
+	m.mu.RLock()
+	dir := m.envsDirName
+	m.mu.RUnlock()
+	if dir == "" {
+		return defaultEnvsDirName
+	}
+	return dir
+}
+
+func (m *Manager) EnvsPath() (string, error) {
+	base, err := m.BasePath()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, envsDirName), nil
+	return filepath.Join(base, m.EnvsDirName()), nil
 }
 
-func ResolveEnvPath(name string) (string, error) {
+func (m *Manager) ResolveEnvPath(name string) (string, error) {
 	if strings.TrimSpace(name) == "" {
 		return "", errors.New("environment name is required")
 	}
-	envsPath, err := EnvsPath()
+	envsPath, err := m.EnvsPath()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(envsPath, name), nil
 }
 
-func EnsureDefaultEnvironment() error {
-	if err := EnsureBaseStructure(); err != nil {
+func (m *Manager) EnsureDefaultEnvironment() error {
+	if err := m.EnsureBaseStructure(); err != nil {
 		return err
 	}
-	if !Exists("default") {
-		if err := Create("default"); err != nil {
+	if !m.Exists("default") {
+		if err := m.Create("default"); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func EnsureBaseStructure() error {
-	base, err := BasePath()
+func (m *Manager) EnsureBaseStructure() error {
+	base, err := m.BasePath()
 	if err != nil {
 		return err
 	}
-	envsPath, err := EnvsPath()
+	envsPath, err := m.EnvsPath()
 	if err != nil {
 		return err
 	}
@@ -89,8 +168,8 @@ func EnsureBaseStructure() error {
 	return nil
 }
 
-func Exists(name string) bool {
-	envPath, err := ResolveEnvPath(name)
+func (m *Manager) Exists(name string) bool {
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return false
 	}
@@ -98,11 +177,11 @@ func Exists(name string) bool {
 	return err == nil && stat.IsDir()
 }
 
-func Create(name string) error {
-	if err := EnsureBaseStructure(); err != nil {
+func (m *Manager) Create(name string) error {
+	if err := m.EnsureBaseStructure(); err != nil {
 		return err
 	}
-	envPath, err := ResolveEnvPath(name)
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return err
 	}
@@ -118,8 +197,8 @@ func Create(name string) error {
 	return nil
 }
 
-func Open(name string) (string, error) {
-	envPath, err := ResolveEnvPath(name)
+func (m *Manager) Open(name string) (string, error) {
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return "", err
 	}
@@ -132,8 +211,8 @@ func Open(name string) (string, error) {
 	return envPath, nil
 }
 
-func Delete(name string) error {
-	envPath, err := ResolveEnvPath(name)
+func (m *Manager) Delete(name string) error {
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return err
 	}
@@ -146,8 +225,8 @@ func Delete(name string) error {
 	return os.RemoveAll(envPath)
 }
 
-func Clear(name string, keepHistory bool) error {
-	envPath, err := ResolveEnvPath(name)
+func (m *Manager) Clear(name string, keepHistory bool) error {
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return err
 	}
@@ -157,7 +236,7 @@ func Clear(name string, keepHistory bool) error {
 		}
 		return err
 	}
-	if err := SaveState(name, map[string]any{}); err != nil {
+	if err := m.SaveState(name, map[string]any{}); err != nil {
 		return err
 	}
 	if keepHistory {
@@ -166,12 +245,12 @@ func Clear(name string, keepHistory bool) error {
 	return os.WriteFile(filepath.Join(envPath, "history.txt"), []byte(""), 0o644)
 }
 
-func Rename(oldName, newName string) error {
-	oldPath, err := ResolveEnvPath(oldName)
+func (m *Manager) Rename(oldName, newName string) error {
+	oldPath, err := m.ResolveEnvPath(oldName)
 	if err != nil {
 		return err
 	}
-	newPath, err := ResolveEnvPath(newName)
+	newPath, err := m.ResolveEnvPath(newName)
 	if err != nil {
 		return err
 	}
@@ -187,12 +266,12 @@ func Rename(oldName, newName string) error {
 	return os.Rename(oldPath, newPath)
 }
 
-func List() ([]EnvironmentInfo, error) {
-	envsPath, err := EnvsPath()
+func (m *Manager) List() ([]EnvironmentInfo, error) {
+	envsPath, err := m.EnvsPath()
 	if err != nil {
 		return nil, err
 	}
-	if err := EnsureBaseStructure(); err != nil {
+	if err := m.EnsureBaseStructure(); err != nil {
 		return nil, err
 	}
 	entries, err := os.ReadDir(envsPath)
@@ -205,7 +284,7 @@ func List() ([]EnvironmentInfo, error) {
 			continue
 		}
 		name := entry.Name()
-		info, err := Info(name)
+		info, err := m.Info(name)
 		if err != nil {
 			continue
 		}
@@ -215,12 +294,12 @@ func List() ([]EnvironmentInfo, error) {
 	return infos, nil
 }
 
-func Info(name string) (EnvironmentInfo, error) {
-	envPath, err := ResolveEnvPath(name)
+func (m *Manager) Info(name string) (EnvironmentInfo, error) {
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return EnvironmentInfo{}, err
 	}
-	state, err := LoadState(name)
+	state, err := m.LoadState(name)
 	if err != nil {
 		state = &State{Variables: map[string]SerializedVariable{}}
 	}
@@ -237,8 +316,8 @@ func Info(name string) (EnvironmentInfo, error) {
 	return info, nil
 }
 
-func Export(name, outputPath string) error {
-	envPath, err := ResolveEnvPath(name)
+func (m *Manager) Export(name, outputPath string) error {
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return err
 	}
@@ -249,12 +328,12 @@ func Export(name, outputPath string) error {
 		return err
 	}
 
-	state, err := LoadState(name)
+	state, err := m.LoadState(name)
 	if err != nil {
 		state = &State{Variables: map[string]SerializedVariable{}, LastAccess: ""}
 	}
 
-	history, err := ReadHistory(name)
+	history, err := m.ReadHistory(name)
 	if err != nil {
 		history = []string{}
 	}
@@ -288,7 +367,7 @@ func Export(name, outputPath string) error {
 	return os.WriteFile(outputPath, bytes, 0o644)
 }
 
-func Import(inputPath, targetName string, force bool) (string, error) {
+func (m *Manager) Import(inputPath, targetName string, force bool) (string, error) {
 	bytes, err := os.ReadFile(inputPath)
 	if err != nil {
 		return "", err
@@ -307,21 +386,21 @@ func Import(inputPath, targetName string, force bool) (string, error) {
 		return "", errors.New("environment name is required")
 	}
 
-	if err := EnsureBaseStructure(); err != nil {
+	if err := m.EnsureBaseStructure(); err != nil {
 		return "", err
 	}
 
-	envPath, err := ResolveEnvPath(name)
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return "", err
 	}
 
-	if !Exists(name) {
-		if err := Create(name); err != nil {
+	if !m.Exists(name) {
+		if err := m.Create(name); err != nil {
 			return "", err
 		}
 	} else if !force {
-		empty, err := isEnvironmentEmpty(name)
+		empty, err := m.isEnvironmentEmpty(name)
 		if err != nil {
 			return "", err
 		}
@@ -373,18 +452,18 @@ func Import(inputPath, targetName string, force bool) (string, error) {
 	return name, nil
 }
 
-func isEnvironmentEmpty(name string) (bool, error) {
-	state, err := LoadState(name)
+func (m *Manager) isEnvironmentEmpty(name string) (bool, error) {
+	state, err := m.LoadState(name)
 	if err == nil && state != nil && len(state.Variables) > 0 {
 		return false, nil
 	}
 
-	history, err := ReadHistory(name)
+	history, err := m.ReadHistory(name)
 	if err == nil && len(history) > 0 {
 		return false, nil
 	}
 
-	envPath, err := ResolveEnvPath(name)
+	envPath, err := m.ResolveEnvPath(name)
 	if err != nil {
 		return false, err
 	}
@@ -424,4 +503,28 @@ func writeDefaultFiles(envPath string) error {
 		return err
 	}
 	return nil
+}
+
+// Package-level wrappers around the default Manager. These exist for
+// backward compatibility with code that doesn't yet thread a Manager
+// through. New code should prefer NewManager + method calls.
+
+func BasePath() (string, error)               { return defaultManager.BasePath() }
+func EnvsPath() (string, error)                { return defaultManager.EnvsPath() }
+func ResolveEnvPath(name string) (string, error) {
+	return defaultManager.ResolveEnvPath(name)
+}
+func EnsureDefaultEnvironment() error           { return defaultManager.EnsureDefaultEnvironment() }
+func EnsureBaseStructure() error                { return defaultManager.EnsureBaseStructure() }
+func Exists(name string) bool                   { return defaultManager.Exists(name) }
+func Create(name string) error                  { return defaultManager.Create(name) }
+func Open(name string) (string, error)          { return defaultManager.Open(name) }
+func Delete(name string) error                  { return defaultManager.Delete(name) }
+func Clear(name string, keepHistory bool) error { return defaultManager.Clear(name, keepHistory) }
+func Rename(oldName, newName string) error      { return defaultManager.Rename(oldName, newName) }
+func List() ([]EnvironmentInfo, error)          { return defaultManager.List() }
+func Info(name string) (EnvironmentInfo, error) { return defaultManager.Info(name) }
+func Export(name, outputPath string) error      { return defaultManager.Export(name, outputPath) }
+func Import(inputPath, targetName string, force bool) (string, error) {
+	return defaultManager.Import(inputPath, targetName, force)
 }

--- a/cli/env/manager_test.go
+++ b/cli/env/manager_test.go
@@ -14,7 +14,171 @@ func setupTempHome(t *testing.T) string {
 	t.Setenv("HOME", home)
 	t.Setenv("HOMEDRIVE", "")
 	t.Setenv("HOMEPATH", "")
+	t.Cleanup(func() { SetBasePath("") })
 	return home
+}
+
+func TestManagerIsolatedFromDefault(t *testing.T) {
+	setupTempHome(t)
+
+	custom := filepath.Join(t.TempDir(), "scoped")
+	mgr := NewManager(custom, "")
+
+	// Operating on the per-session manager should not touch the default
+	// manager's view (which still resolves to <home>/.insyra).
+	if err := mgr.EnsureDefaultEnvironment(); err != nil {
+		t.Fatalf("manager EnsureDefaultEnvironment: %v", err)
+	}
+
+	wantMgrPath := filepath.Join(custom, "envs", "default")
+	if _, err := os.Stat(wantMgrPath); err != nil {
+		t.Fatalf("manager-scoped default env missing: %v", err)
+	}
+
+	// Default manager root must not have been created by mgr's operations.
+	defaultBase, err := Default().BasePath()
+	if err != nil {
+		t.Fatalf("default BasePath: %v", err)
+	}
+	if defaultBase == custom {
+		t.Fatalf("default manager unexpectedly inherits custom path")
+	}
+}
+
+func TestTwoManagersWriteToOwnRoots(t *testing.T) {
+	setupTempHome(t)
+
+	rootA := filepath.Join(t.TempDir(), "A")
+	rootB := filepath.Join(t.TempDir(), "B")
+	mgrA := NewManager(rootA, "")
+	mgrB := NewManager(rootB, "")
+
+	if err := mgrA.EnsureDefaultEnvironment(); err != nil {
+		t.Fatalf("mgrA ensure: %v", err)
+	}
+	if err := mgrB.EnsureDefaultEnvironment(); err != nil {
+		t.Fatalf("mgrB ensure: %v", err)
+	}
+
+	if err := mgrA.SaveState("default", map[string]any{"only_in_a": 1}); err != nil {
+		t.Fatalf("mgrA save: %v", err)
+	}
+	if err := mgrB.SaveState("default", map[string]any{"only_in_b": 2}); err != nil {
+		t.Fatalf("mgrB save: %v", err)
+	}
+
+	stateA, err := mgrA.LoadState("default")
+	if err != nil {
+		t.Fatalf("mgrA load: %v", err)
+	}
+	stateB, err := mgrB.LoadState("default")
+	if err != nil {
+		t.Fatalf("mgrB load: %v", err)
+	}
+
+	if _, ok := stateA.Variables["only_in_a"]; !ok {
+		t.Fatalf("mgrA missing only_in_a")
+	}
+	if _, ok := stateA.Variables["only_in_b"]; ok {
+		t.Fatalf("mgrA leaked only_in_b")
+	}
+	if _, ok := stateB.Variables["only_in_b"]; !ok {
+		t.Fatalf("mgrB missing only_in_b")
+	}
+	if _, ok := stateB.Variables["only_in_a"]; ok {
+		t.Fatalf("mgrB leaked only_in_a")
+	}
+}
+
+func TestManagerCustomEnvsDirName(t *testing.T) {
+	setupTempHome(t)
+
+	root := filepath.Join(t.TempDir(), "ws", ".idensyra")
+	mgr := NewManager(root, "insights")
+
+	if got := mgr.EnvsDirName(); got != "insights" {
+		t.Fatalf("EnvsDirName = %q, want %q", got, "insights")
+	}
+
+	envsPath, err := mgr.EnvsPath()
+	if err != nil {
+		t.Fatalf("EnvsPath: %v", err)
+	}
+	if want := filepath.Join(root, "insights"); envsPath != want {
+		t.Fatalf("EnvsPath = %q, want %q", envsPath, want)
+	}
+
+	if err := mgr.EnsureDefaultEnvironment(); err != nil {
+		t.Fatalf("EnsureDefaultEnvironment: %v", err)
+	}
+
+	wantEnvPath := filepath.Join(root, "insights", "default")
+	if _, err := os.Stat(filepath.Join(wantEnvPath, "state.json")); err != nil {
+		t.Fatalf("state.json missing under custom envs dir: %v", err)
+	}
+
+	// The legacy "envs" subfolder must NOT have been created.
+	if _, err := os.Stat(filepath.Join(root, "envs")); !os.IsNotExist(err) {
+		t.Fatalf("default envs/ should not exist when custom name is used")
+	}
+}
+
+func TestManagerEmptyEnvsDirNameDefaults(t *testing.T) {
+	setupTempHome(t)
+
+	root := filepath.Join(t.TempDir(), "default-envsname")
+	mgr := NewManager(root, "")
+
+	if got := mgr.EnvsDirName(); got != "envs" {
+		t.Fatalf("EnvsDirName = %q, want %q", got, "envs")
+	}
+}
+
+func TestSetBasePathOverridesDefault(t *testing.T) {
+	setupTempHome(t)
+
+	custom := filepath.Join(t.TempDir(), "workspace", ".idensyra")
+	SetBasePath(custom)
+
+	got, err := BasePath()
+	if err != nil {
+		t.Fatalf("BasePath after override failed: %v", err)
+	}
+	if got != custom {
+		t.Fatalf("BasePath = %q, want %q", got, custom)
+	}
+
+	if err := Create("scoped"); err != nil {
+		t.Fatalf("create under override failed: %v", err)
+	}
+
+	envPath, err := ResolveEnvPath("scoped")
+	if err != nil {
+		t.Fatalf("resolve under override failed: %v", err)
+	}
+	expected := filepath.Join(custom, "envs", "scoped")
+	if envPath != expected {
+		t.Fatalf("ResolveEnvPath = %q, want %q", envPath, expected)
+	}
+	if _, err := os.Stat(filepath.Join(envPath, "state.json")); err != nil {
+		t.Fatalf("state.json missing under override: %v", err)
+	}
+}
+
+func TestSetBasePathEmptyRestoresDefault(t *testing.T) {
+	home := setupTempHome(t)
+
+	SetBasePath(filepath.Join(t.TempDir(), "elsewhere"))
+	SetBasePath("")
+
+	got, err := BasePath()
+	if err != nil {
+		t.Fatalf("BasePath after reset failed: %v", err)
+	}
+	expected := filepath.Join(home, ".insyra")
+	if got != expected {
+		t.Fatalf("BasePath = %q, want %q", got, expected)
+	}
 }
 
 func TestEnvironmentCRUD(t *testing.T) {

--- a/cli/env/state.go
+++ b/cli/env/state.go
@@ -21,8 +21,8 @@ type State struct {
 	LastAccess string                        `json:"lastAccess"`
 }
 
-func SaveState(envName string, vars map[string]any) error {
-	envPath, err := ResolveEnvPath(envName)
+func (m *Manager) SaveState(envName string, vars map[string]any) error {
+	envPath, err := m.ResolveEnvPath(envName)
 	if err != nil {
 		return err
 	}
@@ -40,8 +40,8 @@ func SaveState(envName string, vars map[string]any) error {
 	return os.WriteFile(filepath.Join(envPath, "state.json"), payload, 0o644)
 }
 
-func LoadState(envName string) (*State, error) {
-	envPath, err := ResolveEnvPath(envName)
+func (m *Manager) LoadState(envName string) (*State, error) {
+	envPath, err := m.ResolveEnvPath(envName)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +59,8 @@ func LoadState(envName string) (*State, error) {
 	return &state, nil
 }
 
-func RestoreVariables(envName string) (map[string]any, error) {
-	state, err := LoadState(envName)
+func (m *Manager) RestoreVariables(envName string) (map[string]any, error) {
+	state, err := m.LoadState(envName)
 	if err != nil {
 		return nil, err
 	}
@@ -118,8 +118,8 @@ func deserializeVariable(serialized SerializedVariable) any {
 	return serialized.Data
 }
 
-func AppendHistory(envName, command string) error {
-	envPath, err := ResolveEnvPath(envName)
+func (m *Manager) AppendHistory(envName, command string) error {
+	envPath, err := m.ResolveEnvPath(envName)
 	if err != nil {
 		return err
 	}
@@ -135,8 +135,8 @@ func AppendHistory(envName, command string) error {
 	return err
 }
 
-func ReadHistory(envName string) ([]string, error) {
-	envPath, err := ResolveEnvPath(envName)
+func (m *Manager) ReadHistory(envName string) ([]string, error) {
+	envPath, err := m.ResolveEnvPath(envName)
 	if err != nil {
 		return nil, err
 	}
@@ -163,4 +163,26 @@ func ReadHistory(envName string) ([]string, error) {
 		lines = append(lines, current)
 	}
 	return lines, nil
+}
+
+// Package-level wrappers around the default Manager.
+
+func SaveState(envName string, vars map[string]any) error {
+	return defaultManager.SaveState(envName, vars)
+}
+
+func LoadState(envName string) (*State, error) {
+	return defaultManager.LoadState(envName)
+}
+
+func RestoreVariables(envName string) (map[string]any, error) {
+	return defaultManager.RestoreVariables(envName)
+}
+
+func AppendHistory(envName, command string) error {
+	return defaultManager.AppendHistory(envName, command)
+}
+
+func ReadHistory(envName string) ([]string, error) {
+	return defaultManager.ReadHistory(envName)
 }

--- a/cli/repl/api.go
+++ b/cli/repl/api.go
@@ -2,6 +2,7 @@ package repl
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,8 +16,17 @@ type DSLSession struct {
 	ctx *commands.ExecContext
 }
 
-func NewDSLSession(envName string, output io.Writer) (*DSLSession, error) {
-	if err := env.EnsureDefaultEnvironment(); err != nil {
+// NewDSLSession creates a DSL session bound to mgr's environment storage.
+//
+// mgr must be non-nil — pass env.Default() to use the standard
+// <UserHomeDir>/.insyra root, or env.NewManager(path) for a custom one.
+// envName "" defaults to "default". output nil silently discards.
+func NewDSLSession(mgr *env.Manager, envName string, output io.Writer) (*DSLSession, error) {
+	if mgr == nil {
+		return nil, errors.New("dsl: env manager is required (pass env.Default() or env.NewManager(path))")
+	}
+
+	if err := mgr.EnsureDefaultEnvironment(); err != nil {
 		return nil, err
 	}
 
@@ -24,12 +34,12 @@ func NewDSLSession(envName string, output io.Writer) (*DSLSession, error) {
 		envName = "default"
 	}
 
-	envPath, err := env.Open(envName)
+	envPath, err := mgr.Open(envName)
 	if err != nil {
 		return nil, err
 	}
 
-	vars, err := env.RestoreVariables(envName)
+	vars, err := mgr.RestoreVariables(envName)
 	if err != nil {
 		vars = map[string]any{}
 	}
@@ -44,6 +54,7 @@ func NewDSLSession(envName string, output io.Writer) (*DSLSession, error) {
 			EnvPath: envPath,
 			Vars:    vars,
 			Output:  output,
+			Env:     mgr,
 		},
 	}, nil
 }
@@ -67,8 +78,8 @@ func (session *DSLSession) Execute(line string) error {
 		return err
 	}
 
-	_ = env.AppendHistory(session.ctx.EnvName, trimmed)
-	return env.SaveState(session.ctx.EnvName, session.ctx.Vars)
+	_ = session.ctx.Env.AppendHistory(session.ctx.EnvName, trimmed)
+	return session.ctx.Env.SaveState(session.ctx.EnvName, session.ctx.Vars)
 }
 
 func (session *DSLSession) Context() *commands.ExecContext {

--- a/cli/repl/api_test.go
+++ b/cli/repl/api_test.go
@@ -16,13 +16,153 @@ func setupTempHome(t *testing.T) string {
 	t.Setenv("HOME", home)
 	t.Setenv("HOMEDRIVE", "")
 	t.Setenv("HOMEPATH", "")
+	t.Cleanup(func() { env.SetBasePath("") })
 	return home
+}
+
+func TestNewDSLSessionRequiresManager(t *testing.T) {
+	if _, err := NewDSLSession(nil, "default", nil); err == nil {
+		t.Fatalf("expected error when manager is nil")
+	}
+}
+
+func TestNewDSLSessionWithCustomManager(t *testing.T) {
+	setupTempHome(t)
+
+	workspace := filepath.Join(t.TempDir(), "workspace", ".idensyra")
+	mgr := env.NewManager(workspace, "")
+
+	session, err := NewDSLSession(mgr, "default", nil)
+	if err != nil {
+		t.Fatalf("NewDSLSession with custom manager failed: %v", err)
+	}
+
+	expected := filepath.Join(workspace, "envs", "default")
+	if session.Context().EnvPath != expected {
+		t.Fatalf("EnvPath = %q, want %q", session.Context().EnvPath, expected)
+	}
+
+	if err := session.Execute("newdl 1 2 3 as x"); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	statePath := filepath.Join(expected, "state.json")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state.json under workspace missing: %v", err)
+	}
+}
+
+func TestNewDSLSessionWithCustomEnvsDirName(t *testing.T) {
+	setupTempHome(t)
+
+	workspace := filepath.Join(t.TempDir(), "workspace", ".idensyra")
+	mgr := env.NewManager(workspace, "insights")
+
+	session, err := NewDSLSession(mgr, "default", nil)
+	if err != nil {
+		t.Fatalf("NewDSLSession with custom envs dir failed: %v", err)
+	}
+
+	expected := filepath.Join(workspace, "insights", "default")
+	if session.Context().EnvPath != expected {
+		t.Fatalf("EnvPath = %q, want %q", session.Context().EnvPath, expected)
+	}
+
+	if err := session.Execute("newdl 1 2 3 as x"); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(expected, "state.json")); err != nil {
+		t.Fatalf("state.json under insights/ missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "envs")); !os.IsNotExist(err) {
+		t.Fatalf("legacy envs/ should not be created when custom name is used")
+	}
+}
+
+func TestTwoSessionsWithDifferentManagersDoNotInterfere(t *testing.T) {
+	setupTempHome(t)
+
+	wsA := filepath.Join(t.TempDir(), "wsA", ".idensyra")
+	wsB := filepath.Join(t.TempDir(), "wsB", ".idensyra")
+
+	mgrA := env.NewManager(wsA, "")
+	mgrB := env.NewManager(wsB, "")
+
+	sessionA, err := NewDSLSession(mgrA, "default", nil)
+	if err != nil {
+		t.Fatalf("create sessionA: %v", err)
+	}
+	sessionB, err := NewDSLSession(mgrB, "default", nil)
+	if err != nil {
+		t.Fatalf("create sessionB: %v", err)
+	}
+
+	// Interleave commands across sessions. Each session is bound to its own
+	// Manager, so writes go strictly to the matching root.
+	if err := sessionA.Execute("newdl 1 2 3 as a_var"); err != nil {
+		t.Fatalf("sessionA execute: %v", err)
+	}
+	if err := sessionB.Execute("newdl 9 9 as b_var"); err != nil {
+		t.Fatalf("sessionB execute: %v", err)
+	}
+	if err := sessionA.Execute("mean a_var"); err != nil {
+		t.Fatalf("sessionA mean: %v", err)
+	}
+
+	pathA := filepath.Join(wsA, "envs", "default")
+	pathB := filepath.Join(wsB, "envs", "default")
+
+	stateAraw, err := os.ReadFile(filepath.Join(pathA, "state.json"))
+	if err != nil {
+		t.Fatalf("read wsA state: %v", err)
+	}
+	stateBraw, err := os.ReadFile(filepath.Join(pathB, "state.json"))
+	if err != nil {
+		t.Fatalf("read wsB state: %v", err)
+	}
+
+	if !strings.Contains(string(stateAraw), "a_var") || strings.Contains(string(stateAraw), "b_var") {
+		t.Fatalf("wsA state should contain a_var only, got: %s", string(stateAraw))
+	}
+	if !strings.Contains(string(stateBraw), "b_var") || strings.Contains(string(stateBraw), "a_var") {
+		t.Fatalf("wsB state should contain b_var only, got: %s", string(stateBraw))
+	}
+
+	historyA, err := os.ReadFile(filepath.Join(pathA, "history.txt"))
+	if err != nil {
+		t.Fatalf("read wsA history: %v", err)
+	}
+	historyB, err := os.ReadFile(filepath.Join(pathB, "history.txt"))
+	if err != nil {
+		t.Fatalf("read wsB history: %v", err)
+	}
+	if !strings.Contains(string(historyA), "a_var") || strings.Contains(string(historyA), "b_var") {
+		t.Fatalf("wsA history should only contain a_var commands, got: %s", string(historyA))
+	}
+	if !strings.Contains(string(historyB), "b_var") || strings.Contains(string(historyB), "a_var") {
+		t.Fatalf("wsB history should only contain b_var commands, got: %s", string(historyB))
+	}
+}
+
+func TestNewDSLSessionWithDefaultManager(t *testing.T) {
+	home := setupTempHome(t)
+
+	session, err := NewDSLSession(env.Default(), "default", nil)
+	if err != nil {
+		t.Fatalf("NewDSLSession failed: %v", err)
+	}
+
+	expected := filepath.Join(home, ".insyra", "envs", "default")
+	if session.Context().EnvPath != expected {
+		t.Fatalf("EnvPath = %q, want %q", session.Context().EnvPath, expected)
+	}
 }
 
 func TestNewDSLSessionDefaultEnvironment(t *testing.T) {
 	home := setupTempHome(t)
 
-	session, err := NewDSLSession("", nil)
+	session, err := NewDSLSession(env.Default(), "", nil)
 	if err != nil {
 		t.Fatalf("failed to create session: %v", err)
 	}
@@ -42,7 +182,7 @@ func TestNewDSLSessionDefaultEnvironment(t *testing.T) {
 func TestDSLSessionExecutePersistsStateAndHistory(t *testing.T) {
 	setupTempHome(t)
 
-	session, err := NewDSLSession("default", nil)
+	session, err := NewDSLSession(env.Default(), "default", nil)
 	if err != nil {
 		t.Fatalf("failed to create session: %v", err)
 	}
@@ -75,7 +215,7 @@ func TestDSLSessionExecutePersistsStateAndHistory(t *testing.T) {
 func TestDSLSessionExecuteCommentAndUnknownCommand(t *testing.T) {
 	setupTempHome(t)
 
-	session, err := NewDSLSession("default", nil)
+	session, err := NewDSLSession(env.Default(), "default", nil)
 	if err != nil {
 		t.Fatalf("failed to create session: %v", err)
 	}
@@ -92,7 +232,7 @@ func TestDSLSessionExecuteCommentAndUnknownCommand(t *testing.T) {
 func TestDSLSessionExecuteFile(t *testing.T) {
 	setupTempHome(t)
 
-	session, err := NewDSLSession("default", nil)
+	session, err := NewDSLSession(env.Default(), "default", nil)
 	if err != nil {
 		t.Fatalf("failed to create session: %v", err)
 	}
@@ -115,7 +255,7 @@ func TestDSLSessionExecuteFile(t *testing.T) {
 func TestDSLSessionExecuteFileIncludesLineNumber(t *testing.T) {
 	setupTempHome(t)
 
-	session, err := NewDSLSession("default", nil)
+	session, err := NewDSLSession(env.Default(), "default", nil)
 	if err != nil {
 		t.Fatalf("failed to create session: %v", err)
 	}

--- a/cli/repl/repl.go
+++ b/cli/repl/repl.go
@@ -16,6 +16,9 @@ func Start(ctx *commands.ExecContext) error {
 	if ctx == nil {
 		ctx = &commands.ExecContext{}
 	}
+	if ctx.Env == nil {
+		ctx.Env = env.Default()
+	}
 	ctx.InREPL = true
 	defer func() {
 		ctx.InREPL = false
@@ -24,14 +27,14 @@ func Start(ctx *commands.ExecContext) error {
 		ctx.EnvName = "default"
 	}
 	if ctx.EnvPath == "" {
-		envPath, err := env.Open(ctx.EnvName)
+		envPath, err := ctx.Env.Open(ctx.EnvName)
 		if err != nil {
 			return err
 		}
 		ctx.EnvPath = envPath
 	}
 	if ctx.Vars == nil {
-		vars, err := env.RestoreVariables(ctx.EnvName)
+		vars, err := ctx.Env.RestoreVariables(ctx.EnvName)
 		if err != nil {
 			ctx.Vars = map[string]any{}
 		} else {
@@ -54,7 +57,7 @@ func Start(ctx *commands.ExecContext) error {
 		_ = instance.Close()
 	}()
 	defer func() {
-		_ = env.SaveState(ctx.EnvName, ctx.Vars)
+		_ = ctx.Env.SaveState(ctx.EnvName, ctx.Vars)
 	}()
 	defer commands.CloseAllDBConns(ctx)
 
@@ -82,8 +85,8 @@ func Start(ctx *commands.ExecContext) error {
 			_, _ = fmt.Fprintln(instance.Stderr(), style.ErrorText(err.Error()))
 		}
 
-		_ = env.AppendHistory(ctx.EnvName, trimmed)
-		_ = env.SaveState(ctx.EnvName, ctx.Vars)
+		_ = ctx.Env.AppendHistory(ctx.EnvName, trimmed)
+		_ = ctx.Env.SaveState(ctx.EnvName, ctx.Vars)
 
 		if ctx.EnvName != "" {
 			instance.SetPrompt(prompt(ctx.EnvName))

--- a/cli/root.go
+++ b/cli/root.go
@@ -23,17 +23,18 @@ func Execute() error {
 func NewRootCommand() *cobra.Command {
 	execCtx := &commands.ExecContext{
 		OpenREPL: repl.Start,
+		Env:      env.Default(),
 	}
 	cmd := &cobra.Command{
 		Use:          "insyra",
 		Short:        "Insyra CLI and REPL for data analysis",
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := env.EnsureDefaultEnvironment(); err != nil {
+			if err := execCtx.Env.EnsureDefaultEnvironment(); err != nil {
 				return err
 			}
 
-			envPath, err := env.Open(flagEnv)
+			envPath, err := execCtx.Env.Open(flagEnv)
 			if err != nil {
 				return err
 			}
@@ -41,7 +42,7 @@ func NewRootCommand() *cobra.Command {
 			execCtx.EnvName = flagEnv
 			execCtx.EnvPath = envPath
 
-			vars, err := env.RestoreVariables(flagEnv)
+			vars, err := execCtx.Env.RestoreVariables(flagEnv)
 			if err != nil {
 				execCtx.Vars = map[string]any{}
 			} else {
@@ -58,7 +59,7 @@ func NewRootCommand() *cobra.Command {
 			if execCtx.InREPL {
 				return nil
 			}
-			return env.SaveState(execCtx.EnvName, execCtx.Vars)
+			return execCtx.Env.SaveState(execCtx.EnvName, execCtx.Vars)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return repl.Start(execCtx)

--- a/engine/dsl/dsl.go
+++ b/engine/dsl/dsl.go
@@ -3,6 +3,7 @@ package dsl
 import (
 	"io"
 
+	"github.com/HazelnutParadise/insyra/cli/env"
 	"github.com/HazelnutParadise/insyra/cli/repl"
 )
 
@@ -11,10 +12,15 @@ import (
 // It supports Execute(line), ExecuteFile(path), and Context().
 type Session = repl.DSLSession
 
-// NewSession creates a DSL session bound to an Insyra environment.
+// NewSession creates a DSL session bound to mgr's environment storage.
 //
-// envName empty string means "default".
-// output nil means discard output.
-func NewSession(envName string, output io.Writer) (*Session, error) {
-	return repl.NewDSLSession(envName, output)
+// mgr is required: pass env.Default() to use the standard
+// <UserHomeDir>/.insyra root, or env.NewManager(path) for a custom root
+// (e.g. per-workspace embedding). Each session keeps its own Manager, so
+// concurrent sessions in the same process can target different roots
+// without interfering with each other.
+//
+// envName "" defaults to "default". output nil silently discards.
+func NewSession(mgr *env.Manager, envName string, output io.Writer) (*Session, error) {
+	return repl.NewDSLSession(mgr, envName, output)
 }

--- a/engine/dsl/dsl_test.go
+++ b/engine/dsl/dsl_test.go
@@ -1,11 +1,28 @@
 package dsl
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/HazelnutParadise/insyra/cli/env"
 )
 
+func setupTempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Cleanup(func() { env.SetBasePath("") })
+	return home
+}
+
 func TestNewSessionAndExecute(t *testing.T) {
-	session, err := NewSession("", nil)
+	setupTempHome(t)
+
+	session, err := NewSession(env.Default(), "", nil)
 	if err != nil {
 		t.Fatalf("new session failed: %v", err)
 	}
@@ -18,5 +35,35 @@ func TestNewSessionAndExecute(t *testing.T) {
 	}
 	if err := session.Execute("mean x"); err != nil {
 		t.Fatalf("execute failed: %v", err)
+	}
+}
+
+func TestNewSessionWithCustomManager(t *testing.T) {
+	setupTempHome(t)
+
+	workspace := filepath.Join(t.TempDir(), "ws", ".idensyra")
+	mgr := env.NewManager(workspace, "")
+
+	session, err := NewSession(mgr, "default", nil)
+	if err != nil {
+		t.Fatalf("NewSession with custom manager failed: %v", err)
+	}
+
+	want := filepath.Join(workspace, "envs", "default")
+	if got := session.Context().EnvPath; got != want {
+		t.Fatalf("EnvPath = %q, want %q", got, want)
+	}
+
+	if err := session.Execute("newdl 10 20 as v"); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(want, "state.json")); err != nil {
+		t.Fatalf("state.json missing under custom manager root: %v", err)
+	}
+}
+
+func TestNewSessionRequiresManager(t *testing.T) {
+	if _, err := NewSession(nil, "default", nil); err == nil {
+		t.Fatalf("expected error when manager is nil")
 	}
 }

--- a/skills/use-insyra-cli/SKILL.md
+++ b/skills/use-insyra-cli/SKILL.md
@@ -32,11 +32,12 @@ package main
 import (
   "fmt"
 
+  "github.com/HazelnutParadise/insyra/cli/env"
   "github.com/HazelnutParadise/insyra/engine/dsl"
 )
 
 func main() {
-  session, err := dsl.NewSession("default", nil)
+  session, err := dsl.NewSession(env.Default(), "default", nil)
   if err != nil {
     panic(err)
   }
@@ -58,6 +59,7 @@ Notes:
 - `ExecuteFile` runs a `.isr` file directly in-process and returns line-numbered errors.
 - State/history are persisted after each successful command.
 - Empty line and `# comment` line are ignored.
+- Pass `env.NewManager("/path/to/root", "")` instead of `env.Default()` to store environments outside `~/.insyra` (e.g. for per-workspace embedding). The second argument renames the per-env subfolder ("" defaults to `"envs"`; e.g. `env.NewManager(workspace, "insights")` gives `<workspace>/insights/<env>/`). Each session is bound to its own Manager.
 
 ## Agent workflow (recommended)
 


### PR DESCRIPTION
## Summary

Resolves #160. Refactors `cli/env` from package-level globals to a `Manager` type, threads it per-session through `ExecContext`, and lets embedders pick their own storage root and per-env subfolder name.

- `env.Manager` owns one base path + one envs subfolder name; all CRUD/state/history/config operations are now methods on it
- `dsl.NewSession(mgr, envName, output)` requires a Manager — `env.Default()` for `~/.insyra/envs/`, `env.NewManager(base, envsDir)` for custom (e.g. `<workspace>/.idensyra/insights/<env>/`)
- Multiple DSL sessions in the same process can target different roots without interference (each session keeps its own Manager — no shared global state)
- Package-level functions (`env.Create`, `env.SaveState`, `env.SetBasePath`, …) preserved as thin wrappers around `env.Default()` so anything not yet on the Manager API keeps working

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cli/... ./engine/...`
- [x] `go test ./cli/... ./engine/...`
- [x] New tests covering:
  - `TestTwoManagersWriteToOwnRoots` (env)
  - `TestManagerCustomEnvsDirName` (env)
  - `TestTwoSessionsWithDifferentManagersDoNotInterfere` (repl)
  - `TestNewDSLSessionWithCustomEnvsDirName` (repl)
  - `TestNewSessionRequiresManager` (dsl)

## Breaking change

`engine/dsl.NewSession` and `cli/repl.NewDSLSession` now take `*env.Manager` as the first arg. The previous signature `NewSession(envName, output)` no longer compiles — callers should pass `env.Default()` for the same behavior:

```go
// before
session, _ := dsl.NewSession("default", out)
// after
session, _ := dsl.NewSession(env.Default(), "default", out)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)