### PR TITLE
feat(impute): add missing-value imputation methods + fillna CLI (#165)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ pca.prof
 .claude/worktrees/
 .claude/settings.local.json
 
+/.codex-go-build

--- a/Docs/DataList.md
+++ b/Docs/DataList.md
@@ -772,6 +772,39 @@ dl.FillNaNWithMean()
 // NaN values are replaced with mean (3.0)
 ```
 
+### Missing-Value Fill Methods
+
+```go
+func (dl *DataList) FillForward(limit ...int) *DataList
+func (dl *DataList) FillBackward(limit ...int) *DataList
+func (dl *DataList) FillWithMedian() *DataList
+func (dl *DataList) FillWithMode() *DataList
+func (dl *DataList) FillByInterpolation(extrapolate ...bool) *DataList
+```
+
+**Description:** Fills `nil` and `math.NaN()` values in place. `FillForward` uses the most recent observed value, `FillBackward` uses the next observed value, `FillWithMedian` uses observed numeric values, `FillWithMode` works with any observed value type, and `FillByInterpolation` linearly fills numeric gaps by index.
+
+**Parameters:**
+
+- `limit` (optional): Maximum consecutive values to fill for forward/backward fill. `0` or omitted means unlimited.
+- `extrapolate` (optional): When `true`, `FillByInterpolation` also fills leading and trailing numeric gaps.
+
+**Returns:**
+
+- `*DataList`: Reference to the modified DataList
+
+**Example:**
+
+```go
+dl := insyra.NewDataList(1.0, nil, math.NaN(), 4.0)
+dl.FillByInterpolation()
+// dl now contains: [1.0, 2.0, 3.0, 4.0]
+
+labels := insyra.NewDataList("A", nil, "A", math.NaN())
+labels.FillWithMode()
+// labels now contains: ["A", "A", "A", "A"]
+```
+
 ### ReplaceOutliers
 
 ```go
@@ -1749,7 +1782,7 @@ dl.Capitalize()
 func (dl *DataList) LinearInterpolation(x float64) float64
 ```
 
-**Description:** Performs linear interpolation for a given x value.
+**Description:** Performs linear interpolation for a given x value. To fill missing values in a sequence by linear interpolation, use `FillByInterpolation`.
 
 **Parameters:**
 

--- a/Docs/DataTable.md
+++ b/Docs/DataTable.md
@@ -2550,6 +2550,36 @@ sampled := dt.SimpleRandomSample(10)
 
 DataTable provides several methods to replace values within the entire table, a specific row, or a specific column.
 
+### Missing-Value Fill Methods
+
+```go
+func (dt *DataTable) FillForward(limit int, cols ...string) *DataTable
+func (dt *DataTable) FillBackward(limit int, cols ...string) *DataTable
+func (dt *DataTable) FillWithMean(cols ...string) *DataTable
+func (dt *DataTable) FillWithMedian(cols ...string) *DataTable
+func (dt *DataTable) FillWithMode(cols ...string) *DataTable
+func (dt *DataTable) FillByInterpolation(cols ...string) *DataTable
+```
+
+**Description:** Fills `nil` and `math.NaN()` values column by column. When `cols` is omitted, all applicable columns are processed. Mean, median, and interpolation apply only to numeric columns; mode and forward/backward fill can apply to any selected column.
+
+**Parameters:**
+
+- `limit`: Maximum consecutive values to fill for forward/backward fill. `0` means unlimited.
+- `cols` (optional): Column names or Excel-style indices to process.
+
+**Returns:**
+
+- `*DataTable`: Reference to the modified DataTable.
+
+**Example:**
+
+```go
+dt.FillWithMedian("revenue", "cost")
+dt.FillForward(2, "status")
+dt.FillByInterpolation() // all numeric columns
+```
+
 ### Replace
 
 ```go

--- a/Docs/cli-dsl.md
+++ b/Docs/cli-dsl.md
@@ -447,10 +447,30 @@ High-level command map:
 - **Data IO / Creation**: `newdl`, `newdt`, `load`, `read`, `save`, `convert`
 - **Database**: `db` (`connect` / `list` / `tables` / `disconnect`), `load sql`, `save <var> sql`
 - **DataTable Structure / Access**: `addcol`, `addrow`, `dropcol`, `droprow`, `swap`, `transpose`, `rows`, `cols`, `row`, `col`, `get`, `set`, `setrownames`, `setcolnames`
-- **Data Processing**: `filter`, `sort`, `sample`, `find`, `replace`, `clean`, `merge`, `groupby`, `pivot`, `unpivot`, `ccl`, `addcolccl`
+- **Data Processing**: `filter`, `sort`, `sample`, `find`, `replace`, `clean`, `fillna`, `merge`, `groupby`, `pivot`, `unpivot`, `ccl`, `addcolccl`
 - **DataList Stats**: `sum`, `mean`, `median`, `mode`, `stdev`, `var`, `min`, `max`, `range`, `quartile`, `iqr`, `percentile`, `count`, `counter`, `corr`, `cov`, `corrmatrix`, `skewness`, `kurtosis`
-- **Time Series / Transforms**: `rank`, `normalize`, `standardize`, `reverse`, `upper`, `lower`, `capitalize`, `parsenums`, `parsestrings`, `movavg`, `expsmooth`, `diff`, `diffn`, `shift`, `pctchange`, `cumsum`, `cumprod`, `cummax`, `cummin`, `rolling`, `expanding`, `fillnan`
+- **Time Series / Transforms**: `rank`, `normalize`, `standardize`, `reverse`, `upper`, `lower`, `capitalize`, `parsenums`, `parsestrings`, `movavg`, `expsmooth`, `diff`, `diffn`, `shift`, `pctchange`, `cumsum`, `cumprod`, `cummax`, `cummin`, `rolling`, `expanding`, `fillna`
 - **Modeling / Viz / Fetch**: `regression`, `pca`, `kmeans`, `hclust`, `cutree`, `dbscan`, `silhouette`, `knn_classify`, `knn_regress`, `knn_neighbors`, `ttest`, `ztest`, `anova`, `ftest`, `chisq`, `plot`, `fetch`
+
+### Missing-Value Fill Commands
+
+```bash
+fillna <var> mean|median|mode|ffill|bfill|interpolate [cols A,B,C] [limit N] [extrapolate yes|no] [missing nan|nil|both] [as <var>]
+fillnan <var> mean [as <var>]   # deprecated; only fills NaN, mean only
+```
+
+`fillna` clones the input (DataList or DataTable) and saves the filled result under `as <var>` or `$result`. `cols` filters which DataTable columns to touch (ignored for DataList). `limit` caps consecutive forward/backward fills; `extrapolate` controls whether interpolation fills leading/trailing gaps; `missing` selects which kind of missing to fill (default `both`). `mean`, `median`, and `interpolate` skip non-numeric columns; `mode`, `ffill`, and `bfill` work with any selected column type.
+
+`fillnan <var> mean` is a legacy alias kept for backward compatibility — it only fills NaN (leaves nil alone) and only supports the `mean` strategy. New code should use `fillna ... missing nan` instead.
+
+Examples:
+
+```bash
+fillna price interpolate extrapolate yes as price_interp
+fillna status ffill limit 2 missing nan as status_filled
+fillna sales median cols revenue,cost as sales_clean
+fillna sales bfill limit 1 as sales_bfill
+```
 
 ## Full Command Index (Appendix)
 
@@ -496,7 +516,8 @@ Source policy:
 | `expanding` | `expanding <var> <minobs> <reducer> [as <var>]` | Expanding-window reduction (reducer: sum\|mean\|min\|max\|median\|std\|var) |
 | `expsmooth` | `expsmooth <var> <alpha> [as <var>]` | Exponential smoothing |
 | `fetch` | `fetch yahoo <ticker> <method> [params...] [as <var>]` | Fetch external data |
-| `fillnan` | `fillnan <var> mean` | Fill NaN with mean |
+| `fillna` | `fillna <var> mean\|median\|mode\|ffill\|bfill\|interpolate [cols A,B,C] [limit N] [extrapolate yes\|no] [missing nan\|nil\|both] [as <var>]` | Fill missing DataList/DataTable values |
+| `fillnan` | `fillnan <var> mean [as <var>]` | Fill NaN with mean (deprecated alias) |
 | `filter` | `filter <var> <expr> [as <var>]` | Filter DataTable by CCL expression |
 | `find` | `find <var> <value>` | Find rows containing value |
 | `ftest` | `ftest var\|levene\|bartlett ...` | F-test commands |

--- a/cli/commands/timeseries.go
+++ b/cli/commands/timeseries.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -12,7 +13,32 @@ func init() {
 	_ = Register(&CommandHandler{Name: "movavg", Usage: "movavg <var> <window> [as <var>]", Description: "Moving average", Run: runMovAvgCommand})
 	_ = Register(&CommandHandler{Name: "expsmooth", Usage: "expsmooth <var> <alpha> [as <var>]", Description: "Exponential smoothing", Run: runExpSmoothCommand})
 	_ = Register(&CommandHandler{Name: "diff", Usage: "diff <var> [as <var>]", Description: "Difference (legacy, length n-1)", Run: runDiffCommand})
-	_ = Register(&CommandHandler{Name: "fillnan", Usage: "fillnan <var> mean", Description: "Fill NaN with mean", Run: runFillNaNCommand})
+	_ = Register(&CommandHandler{
+		Name:        "fillna",
+		Usage:       "fillna <var> mean|median|mode|ffill|bfill|interpolate [cols A,B,C] [limit N] [extrapolate yes|no] [missing nan|nil|both] [as <var>]",
+		Description: "Fill missing DataList/DataTable values",
+		Forms: []string{
+			"mean|median|interpolate  apply to numeric data only",
+			"mode|ffill|bfill         work with any data type",
+			"cols <A,B,C>             DataTable only; comma-separated column names or indices",
+			"limit <n>                cap consecutive ffill/bfill replacements (0 = unlimited)",
+			"extrapolate yes|no       interpolation only; fill leading/trailing gaps (default no)",
+			"missing nan|nil|both     which kind of missing to fill (default both)",
+		},
+		Examples: []string{
+			"insyra fillna price median as price_filled",
+			"insyra fillna price ffill limit 2 missing nan as price_ffill",
+			"insyra fillna price interpolate extrapolate yes as price_interp",
+			"insyra fillna sales median cols revenue,cost as cleaned",
+		},
+		Run: runFillNACommand,
+	})
+	_ = Register(&CommandHandler{
+		Name:        "fillnan",
+		Usage:       "fillnan <var> mean [as <var>]",
+		Description: "Fill NaN with mean (deprecated alias; prefer 'fillna ... missing nan')",
+		Run:         runFillNaNCommand,
+	})
 
 	_ = Register(&CommandHandler{
 		Name:        "shift",
@@ -127,20 +153,265 @@ func runDiffCommand(ctx *ExecContext, args []string) error {
 	return nil
 }
 
+// runFillNaNCommand handles the legacy `fillnan <var> mean [as <var>]` shape.
+// It only fills NaN (not nil) and only supports the mean strategy. Use `fillna`
+// for the full surface.
 func runFillNaNCommand(ctx *ExecContext, args []string) error {
-	if len(args) < 2 {
-		return fmt.Errorf("usage: fillnan <var> mean")
+	coreArgs, alias := parseAlias(args)
+	if len(coreArgs) < 2 || strings.ToLower(coreArgs[1]) != "mean" {
+		return fmt.Errorf("usage: fillnan <var> mean [as <var>] (use 'fillna' for other strategies)")
 	}
-	if args[1] != "mean" {
-		return fmt.Errorf("only mean is supported")
-	}
-	dl, err := getDataListVar(ctx, args[0])
+	dl, err := getDataListVar(ctx, coreArgs[0])
 	if err != nil {
 		return err
 	}
-	dl.FillNaNWithMean()
-	_, _ = fmt.Fprintln(ctx.Output, "filled NaN with mean")
+	if len(coreArgs) > 2 {
+		return fmt.Errorf("fillnan: unexpected extra args %v (use 'fillna' for options)", coreArgs[2:])
+	}
+	result := dl.Clone().FillNaNWithMean()
+	ctx.Vars[alias] = result
+	_, _ = fmt.Fprintf(ctx.Output, "warning: 'fillnan' is deprecated; use 'fillna %s mean missing nan%s' instead\n", coreArgs[0], aliasSuffix(alias))
+	_, _ = fmt.Fprintf(ctx.Output, "saved as %s\n", alias)
 	return nil
+}
+
+func aliasSuffix(alias string) string {
+	if alias == "" || alias == "$result" {
+		return ""
+	}
+	return " as " + alias
+}
+
+type fillNAOptions struct {
+	Cols        []string
+	Limit       int
+	Extrapolate bool
+	Missing     string // "nan", "nil", or "both" (default)
+}
+
+func runFillNACommand(ctx *ExecContext, args []string) error {
+	coreArgs, alias := parseAlias(args)
+	if len(coreArgs) < 2 {
+		return fmt.Errorf("usage: fillna <var> mean|median|mode|ffill|bfill|interpolate [cols A,B,C] [limit N] [extrapolate yes|no] [missing nan|nil|both] [as <var>]")
+	}
+	strategy := strings.ToLower(coreArgs[1])
+	opts, err := parseFillNAOptions(coreArgs[2:])
+	if err != nil {
+		return err
+	}
+
+	if dt, err := getDataTableVar(ctx, coreArgs[0]); err == nil {
+		result, err := applyFillNAToTable(dt, strategy, opts)
+		if err != nil {
+			return err
+		}
+		ctx.Vars[alias] = result
+		_, _ = fmt.Fprintf(ctx.Output, "saved as %s\n", alias)
+		return nil
+	}
+	if dl, err := getDataListVar(ctx, coreArgs[0]); err == nil {
+		if len(opts.Cols) > 0 {
+			return fmt.Errorf("fillna: 'cols' only applies to DataTable variables")
+		}
+		result, err := applyFillNAToList(dl, strategy, opts)
+		if err != nil {
+			return err
+		}
+		ctx.Vars[alias] = result
+		_, _ = fmt.Fprintf(ctx.Output, "saved as %s\n", alias)
+		return nil
+	}
+	return fmt.Errorf("variable not found: %s", coreArgs[0])
+}
+
+func applyFillNAToList(dl *insyra.DataList, strategy string, opts fillNAOptions) (*insyra.DataList, error) {
+	result := dl.Clone()
+	preserved := snapshotPreservedDL(result, opts.Missing)
+	if err := runListStrategy(result, strategy, opts); err != nil {
+		return nil, err
+	}
+	restorePreservedDL(result, opts.Missing, preserved)
+	return result, nil
+}
+
+func applyFillNAToTable(dt *insyra.DataTable, strategy string, opts fillNAOptions) (*insyra.DataTable, error) {
+	result := dt.Clone()
+	preserved := snapshotPreservedDT(result, opts.Cols, opts.Missing)
+	if err := runTableStrategy(result, strategy, opts); err != nil {
+		return nil, err
+	}
+	restorePreservedDT(result, opts.Missing, preserved)
+	return result, nil
+}
+
+func runListStrategy(dl *insyra.DataList, strategy string, opts fillNAOptions) error {
+	switch strategy {
+	case "mean":
+		dl.FillWithMean()
+	case "median":
+		dl.FillWithMedian()
+	case "mode":
+		dl.FillWithMode()
+	case "ffill":
+		dl.FillForward(opts.Limit)
+	case "bfill":
+		dl.FillBackward(opts.Limit)
+	case "interpolate":
+		dl.FillByInterpolation(opts.Extrapolate)
+	default:
+		return fmt.Errorf("fillna: unknown strategy %q (supported: mean, median, mode, ffill, bfill, interpolate)", strategy)
+	}
+	return nil
+}
+
+func runTableStrategy(dt *insyra.DataTable, strategy string, opts fillNAOptions) error {
+	switch strategy {
+	case "mean":
+		dt.FillWithMean(opts.Cols...)
+	case "median":
+		dt.FillWithMedian(opts.Cols...)
+	case "mode":
+		dt.FillWithMode(opts.Cols...)
+	case "ffill":
+		dt.FillForward(opts.Limit, opts.Cols...)
+	case "bfill":
+		dt.FillBackward(opts.Limit, opts.Cols...)
+	case "interpolate":
+		dt.FillByInterpolation(opts.Cols...)
+	default:
+		return fmt.Errorf("fillna: unknown strategy %q (supported: mean, median, mode, ffill, bfill, interpolate)", strategy)
+	}
+	return nil
+}
+
+// snapshotPreservedDL records positions whose original value must be restored
+// after the fill runs. With missing=="nan", nil positions are preserved (so the
+// fill only sticks at NaN positions). With missing=="nil", NaN positions are
+// preserved. With "both" (or unset), nothing is preserved.
+func snapshotPreservedDL(dl *insyra.DataList, missing string) []int {
+	if missing != "nan" && missing != "nil" {
+		return nil
+	}
+	var positions []int
+	for i, v := range dl.Data() {
+		if missing == "nan" && v == nil {
+			positions = append(positions, i)
+		} else if missing == "nil" {
+			if f, ok := v.(float64); ok && math.IsNaN(f) {
+				positions = append(positions, i)
+			}
+		}
+	}
+	return positions
+}
+
+func restorePreservedDL(dl *insyra.DataList, missing string, positions []int) {
+	if len(positions) == 0 {
+		return
+	}
+	var restoreVal any
+	if missing == "nan" {
+		restoreVal = nil
+	} else {
+		restoreVal = math.NaN()
+	}
+	for _, i := range positions {
+		dl.Update(i, restoreVal)
+	}
+}
+
+func snapshotPreservedDT(dt *insyra.DataTable, cols []string, missing string) map[string][]int {
+	if missing != "nan" && missing != "nil" {
+		return nil
+	}
+	targets := cols
+	if len(targets) == 0 {
+		targets = dt.ColNames()
+	}
+	preserved := map[string][]int{}
+	for _, col := range targets {
+		dl := dt.GetColByName(col)
+		if dl == nil {
+			continue
+		}
+		positions := snapshotPreservedDL(dl, missing)
+		if len(positions) > 0 {
+			preserved[col] = positions
+		}
+	}
+	return preserved
+}
+
+func restorePreservedDT(dt *insyra.DataTable, missing string, preserved map[string][]int) {
+	if len(preserved) == 0 {
+		return
+	}
+	for col, positions := range preserved {
+		dl := dt.GetColByName(col)
+		if dl == nil {
+			continue
+		}
+		restorePreservedDL(dl, missing, positions)
+	}
+}
+
+func parseFillNAOptions(args []string) (fillNAOptions, error) {
+	opts := fillNAOptions{Missing: "both"}
+	for i := 0; i < len(args); {
+		key := strings.ToLower(args[i])
+		next := func() (string, error) {
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("fillna: option %q requires a value", args[i])
+			}
+			return args[i+1], nil
+		}
+		switch key {
+		case "cols":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			opts.Cols = parseCSVTokens(v)
+			i += 2
+		case "limit":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 0 {
+				return opts, fmt.Errorf("fillna: invalid limit %q", v)
+			}
+			opts.Limit = n
+			i += 2
+		case "extrapolate":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			b, err := parseFlexBool(v)
+			if err != nil {
+				return opts, fmt.Errorf("fillna: invalid value for extrapolate: %w", err)
+			}
+			opts.Extrapolate = b
+			i += 2
+		case "missing":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			switch strings.ToLower(v) {
+			case "nan", "nil", "both":
+				opts.Missing = strings.ToLower(v)
+			default:
+				return opts, fmt.Errorf("fillna: invalid value for missing %q (supported: nan, nil, both)", v)
+			}
+			i += 2
+		default:
+			return opts, fmt.Errorf("fillna: unknown option %q (supported: cols, limit, extrapolate, missing)", args[i])
+		}
+	}
+	return opts, nil
 }
 
 // ===========================================================================

--- a/cli/commands/timeseries_test.go
+++ b/cli/commands/timeseries_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 
 	insyra "github.com/HazelnutParadise/insyra"
@@ -31,6 +32,19 @@ func resultDL(t *testing.T, ctx *ExecContext, name string) *insyra.DataList {
 		t.Fatalf("expected %q to be *DataList, got %T", name, v)
 	}
 	return dl
+}
+
+func resultDT(t *testing.T, ctx *ExecContext, name string) *insyra.DataTable {
+	t.Helper()
+	v, ok := ctx.Vars[name]
+	if !ok {
+		t.Fatalf("expected variable %q to be set", name)
+	}
+	dt, ok := v.(*insyra.DataTable)
+	if !ok {
+		t.Fatalf("expected %q to be *DataTable, got %T", name, v)
+	}
+	return dt
 }
 
 // approxEqualAny compares two slices element-wise; numeric values use a
@@ -213,6 +227,83 @@ func TestExpandingCommand_MinObsThreshold(t *testing.T) {
 	}
 	if !approxEqualAny(resultDL(t, ctx, "e").Data(), []any{nil, nil, 2.0, 2.5}, 1e-9) {
 		t.Errorf("expanding minobs wrong: %v", resultDL(t, ctx, "e").Data())
+	}
+}
+
+func TestFillNACommand_Interpolate(t *testing.T) {
+	ctx := newWindowCtx(nil, 1.0, nil, 3.0, math.NaN())
+	if err := runFillNACommand(ctx, []string{"x", "interpolate", "extrapolate", "yes", "as", "filled"}); err != nil {
+		t.Fatalf("fillna interpolate failed: %v", err)
+	}
+	if !approxEqualAny(resultDL(t, ctx, "filled").Data(), []any{0.0, 1.0, 2.0, 3.0, 4.0}, 1e-9) {
+		t.Errorf("fillna interpolate wrong: %v", resultDL(t, ctx, "filled").Data())
+	}
+}
+
+func TestFillNACommand_MissingNaNPreservesNil(t *testing.T) {
+	ctx := newWindowCtx(1.0, math.NaN(), nil, 4.0)
+	if err := runFillNACommand(ctx, []string{"x", "ffill", "missing", "nan", "as", "filled"}); err != nil {
+		t.Fatalf("fillna missing=nan failed: %v", err)
+	}
+	if !approxEqualAny(resultDL(t, ctx, "filled").Data(), []any{1.0, 1.0, nil, 4.0}, 1e-9) {
+		t.Errorf("fillna missing=nan wrong: %v", resultDL(t, ctx, "filled").Data())
+	}
+}
+
+func TestFillNACommand_MissingNilPreservesNaN(t *testing.T) {
+	ctx := newWindowCtx(1.0, math.NaN(), nil, 4.0)
+	if err := runFillNACommand(ctx, []string{"x", "ffill", "missing", "nil", "as", "filled"}); err != nil {
+		t.Fatalf("fillna missing=nil failed: %v", err)
+	}
+	got := resultDL(t, ctx, "filled").Data()
+	if len(got) != 4 || got[0] != 1.0 || got[2] != 1.0 || got[3] != 4.0 {
+		t.Errorf("fillna missing=nil wrong shape: %v", got)
+	}
+	if f, ok := got[1].(float64); !ok || !math.IsNaN(f) {
+		t.Errorf("fillna missing=nil should keep NaN at index 1, got %v", got[1])
+	}
+}
+
+func TestFillNACommand_TableMedianCols(t *testing.T) {
+	ctx := &ExecContext{
+		Vars: map[string]any{
+			"t": insyra.NewDataTable(
+				insyra.NewDataList(1.0, nil, 3.0).SetName("num"),
+				insyra.NewDataList("x", nil, "z").SetName("text"),
+			),
+		},
+		Output: &bytes.Buffer{},
+	}
+	if err := runFillNACommand(ctx, []string{"t", "median", "cols", "num,text", "as", "filled"}); err != nil {
+		t.Fatalf("fillna median failed: %v", err)
+	}
+	result := resultDT(t, ctx, "filled")
+	if !approxEqualAny(result.GetColByName("num").Data(), []any{1.0, 2.0, 3.0}, 1e-9) {
+		t.Errorf("fillna numeric col wrong: %v", result.GetColByName("num").Data())
+	}
+	if !approxEqualAny(result.GetColByName("text").Data(), []any{"x", nil, "z"}, 1e-9) {
+		t.Errorf("fillna string col should be skipped: %v", result.GetColByName("text").Data())
+	}
+}
+
+func TestFillNaNLegacy_MeanOnly(t *testing.T) {
+	ctx := newWindowCtx(1.0, math.NaN(), 3.0)
+	if err := runFillNaNCommand(ctx, []string{"x", "mean", "as", "filled"}); err != nil {
+		t.Fatalf("fillnan mean failed: %v", err)
+	}
+	if !approxEqualAny(resultDL(t, ctx, "filled").Data(), []any{1.0, 2.0, 3.0}, 1e-9) {
+		t.Errorf("fillnan mean wrong: %v", resultDL(t, ctx, "filled").Data())
+	}
+	out := ctx.Output.(*bytes.Buffer).String()
+	if !strings.Contains(out, "deprecated") || !strings.Contains(out, "fillna") {
+		t.Errorf("expected deprecation warning pointing to fillna, got: %q", out)
+	}
+}
+
+func TestFillNaNLegacy_RejectsOtherStrategies(t *testing.T) {
+	ctx := newWindowCtx(1.0, math.NaN(), 3.0)
+	if err := runFillNaNCommand(ctx, []string{"x", "median"}); err == nil {
+		t.Error("expected error for non-mean strategy on legacy fillnan")
 	}
 }
 

--- a/datalist_impute.go
+++ b/datalist_impute.go
@@ -1,0 +1,290 @@
+package insyra
+
+import (
+	"math"
+	"reflect"
+	"sort"
+)
+
+func isMissing(v any) bool {
+	if v == nil {
+		return true
+	}
+	if f, ok := v.(float64); ok && math.IsNaN(f) {
+		return true
+	}
+	return false
+}
+
+func imputeLimit(limit []int) int {
+	if len(limit) == 0 || limit[0] <= 0 {
+		return 0
+	}
+	return limit[0]
+}
+
+func numericObservedValues(data []any) []float64 {
+	values := make([]float64, 0, len(data))
+	for _, v := range data {
+		if isMissing(v) {
+			continue
+		}
+		if f, ok := ToFloat64Safe(v); ok {
+			values = append(values, f)
+		}
+	}
+	return values
+}
+
+func numericObservedPoints(data []any) ([]int, []float64, bool) {
+	indices := make([]int, 0, len(data))
+	values := make([]float64, 0, len(data))
+	for i, v := range data {
+		if isMissing(v) {
+			continue
+		}
+		f, ok := ToFloat64Safe(v)
+		if !ok {
+			return nil, nil, false
+		}
+		indices = append(indices, i)
+		values = append(values, f)
+	}
+	return indices, values, true
+}
+
+func hasOnlyNumericObservedValues(dl *DataList) bool {
+	found := false
+	for _, v := range dl.data {
+		if isMissing(v) {
+			continue
+		}
+		if _, ok := ToFloat64Safe(v); !ok {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+// FillForward replaces missing values with the most recent non-missing value.
+func (dl *DataList) FillForward(limit ...int) *DataList {
+	defer func() {
+		go dl.updateTimestamp()
+	}()
+	maxFill := imputeLimit(limit)
+	dl.AtomicDo(func(dl *DataList) {
+		var last any
+		hasLast := false
+		fillCount := 0
+		for i, v := range dl.data {
+			if isMissing(v) {
+				if hasLast && (maxFill == 0 || fillCount < maxFill) {
+					dl.data[i] = last
+				}
+				if hasLast {
+					fillCount++
+				}
+				continue
+			}
+			last = v
+			hasLast = true
+			fillCount = 0
+		}
+	})
+	return dl
+}
+
+// FillBackward replaces missing values with the next non-missing value.
+func (dl *DataList) FillBackward(limit ...int) *DataList {
+	defer func() {
+		go dl.updateTimestamp()
+	}()
+	maxFill := imputeLimit(limit)
+	dl.AtomicDo(func(dl *DataList) {
+		var next any
+		hasNext := false
+		fillCount := 0
+		for i := len(dl.data) - 1; i >= 0; i-- {
+			v := dl.data[i]
+			if isMissing(v) {
+				if hasNext && (maxFill == 0 || fillCount < maxFill) {
+					dl.data[i] = next
+				}
+				if hasNext {
+					fillCount++
+				}
+				continue
+			}
+			next = v
+			hasNext = true
+			fillCount = 0
+		}
+	})
+	return dl
+}
+
+// FillWithMean replaces missing values (NaN and nil) with the mean of observed numeric values.
+func (dl *DataList) FillWithMean() *DataList {
+	defer func() {
+		go dl.updateTimestamp()
+	}()
+	dl.AtomicDo(func(dl *DataList) {
+		values := numericObservedValues(dl.data)
+		if len(values) == 0 {
+			dl.warn("FillWithMean", "No numeric values to compute mean")
+			return
+		}
+		var sum float64
+		for _, v := range values {
+			sum += v
+		}
+		mean := sum / float64(len(values))
+		for i, v := range dl.data {
+			if isMissing(v) {
+				dl.data[i] = mean
+			}
+		}
+	})
+	return dl
+}
+
+// FillWithMedian replaces missing values with the median of observed numeric values.
+func (dl *DataList) FillWithMedian() *DataList {
+	defer func() {
+		go dl.updateTimestamp()
+	}()
+	dl.AtomicDo(func(dl *DataList) {
+		values := numericObservedValues(dl.data)
+		if len(values) == 0 {
+			dl.warn("FillWithMedian", "No numeric values to compute median")
+			return
+		}
+		sort.Float64s(values)
+		mid := len(values) / 2
+		median := values[mid]
+		if len(values)%2 == 0 {
+			median = (values[mid-1] + values[mid]) / 2
+		}
+		for i, v := range dl.data {
+			if isMissing(v) {
+				dl.data[i] = median
+			}
+		}
+	})
+	return dl
+}
+
+// FillWithMode replaces missing values with the first-occurring mode of observed values.
+func (dl *DataList) FillWithMode() *DataList {
+	defer func() {
+		go dl.updateTimestamp()
+	}()
+	type modeEntry struct {
+		value any
+		count int
+		first int
+	}
+	dl.AtomicDo(func(dl *DataList) {
+		entries := []modeEntry{}
+		for i, v := range dl.data {
+			if isMissing(v) {
+				continue
+			}
+			found := false
+			for j := range entries {
+				if reflect.DeepEqual(entries[j].value, v) {
+					entries[j].count++
+					found = true
+					break
+				}
+			}
+			if !found {
+				entries = append(entries, modeEntry{value: v, count: 1, first: i})
+			}
+		}
+		if len(entries) == 0 {
+			dl.warn("FillWithMode", "No non-missing values to compute mode")
+			return
+		}
+		mode := entries[0]
+		for _, entry := range entries[1:] {
+			if entry.count > mode.count || entry.count == mode.count && entry.first < mode.first {
+				mode = entry
+			}
+		}
+		for i, v := range dl.data {
+			if isMissing(v) {
+				dl.data[i] = mode.value
+			}
+		}
+	})
+	return dl
+}
+
+// FillByInterpolation fills missing sequence values by index, unlike LinearInterpolation which evaluates y at x.
+func (dl *DataList) FillByInterpolation(extrapolate ...bool) *DataList {
+	defer func() {
+		go dl.updateTimestamp()
+	}()
+	shouldExtrapolate := len(extrapolate) > 0 && extrapolate[0]
+	dl.AtomicDo(func(dl *DataList) {
+		indices, values, ok := numericObservedPoints(dl.data)
+		if !ok {
+			dl.warn("FillByInterpolation", "DataList contains non-numeric values")
+			return
+		}
+		if len(indices) == 0 {
+			dl.warn("FillByInterpolation", "No numeric values to interpolate")
+			return
+		}
+
+		for p := 0; p < len(indices)-1; p++ {
+			leftIdx := indices[p]
+			rightIdx := indices[p+1]
+			if rightIdx-leftIdx <= 1 {
+				continue
+			}
+			leftVal := values[p]
+			rightVal := values[p+1]
+			step := (rightVal - leftVal) / float64(rightIdx-leftIdx)
+			for i := leftIdx + 1; i < rightIdx; i++ {
+				if isMissing(dl.data[i]) {
+					dl.data[i] = leftVal + step*float64(i-leftIdx)
+				}
+			}
+		}
+
+		if !shouldExtrapolate {
+			return
+		}
+		if len(indices) == 1 {
+			for i, v := range dl.data {
+				if isMissing(v) {
+					dl.data[i] = values[0]
+				}
+			}
+			return
+		}
+
+		firstIdx := indices[0]
+		firstVal := values[0]
+		firstStep := (values[1] - firstVal) / float64(indices[1]-firstIdx)
+		for i := range firstIdx {
+			if isMissing(dl.data[i]) {
+				dl.data[i] = firstVal + firstStep*float64(i-firstIdx)
+			}
+		}
+
+		lastPos := len(indices) - 1
+		lastIdx := indices[lastPos]
+		lastVal := values[lastPos]
+		lastStep := (lastVal - values[lastPos-1]) / float64(lastIdx-indices[lastPos-1])
+		for i := lastIdx + 1; i < len(dl.data); i++ {
+			if isMissing(dl.data[i]) {
+				dl.data[i] = lastVal + lastStep*float64(i-lastIdx)
+			}
+		}
+	})
+	return dl
+}

--- a/datalist_impute_test.go
+++ b/datalist_impute_test.go
@@ -1,0 +1,169 @@
+package insyra
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func assertImputeData(t *testing.T, dl *DataList, want []any) {
+	t.Helper()
+	got := dl.Data()
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d; got %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if wantF, ok := want[i].(float64); ok && math.IsNaN(wantF) {
+			gotF, ok := got[i].(float64)
+			if !ok || !math.IsNaN(gotF) {
+				t.Fatalf("index %d = %#v, want NaN; got all %#v", i, got[i], got)
+			}
+			continue
+		}
+		gotF, gotOK := ToFloat64Safe(got[i])
+		wantF, wantOK := ToFloat64Safe(want[i])
+		if gotOK && wantOK {
+			if math.Abs(gotF-wantF) > 1e-9 {
+				t.Fatalf("index %d = %#v, want %#v; got all %#v", i, got[i], want[i], got)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(got[i], want[i]) {
+			t.Fatalf("index %d = %#v, want %#v; got all %#v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestDataListFillForward(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []any
+		limit []int
+		want  []any
+	}{
+		{"middle", []any{1.0, math.NaN(), nil, 4.0}, nil, []any{1.0, 1.0, 1.0, 4.0}},
+		{"leading", []any{nil, math.NaN(), 2.0, nil}, nil, []any{nil, math.NaN(), 2.0, 2.0}},
+		{"limit", []any{1.0, nil, math.NaN(), nil, 5.0}, []int{2}, []any{1.0, 1.0, 1.0, nil, 5.0}},
+		{"all missing", []any{nil, math.NaN()}, nil, []any{nil, math.NaN()}},
+		{"none missing", []any{1.0, 2.0}, nil, []any{1.0, 2.0}},
+		{"single missing", []any{math.NaN()}, nil, []any{math.NaN()}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dl := NewDataList(tt.input...)
+			dl.FillForward(tt.limit...)
+			assertImputeData(t, dl, tt.want)
+		})
+	}
+}
+
+func TestDataListFillBackward(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []any
+		limit []int
+		want  []any
+	}{
+		{"middle", []any{1.0, math.NaN(), nil, 4.0}, nil, []any{1.0, 4.0, 4.0, 4.0}},
+		{"trailing", []any{nil, 2.0, nil, math.NaN()}, nil, []any{2.0, 2.0, nil, math.NaN()}},
+		{"limit", []any{1.0, nil, math.NaN(), nil, 5.0}, []int{2}, []any{1.0, nil, 5.0, 5.0, 5.0}},
+		{"all missing", []any{nil, math.NaN()}, nil, []any{nil, math.NaN()}},
+		{"none missing", []any{1.0, 2.0}, nil, []any{1.0, 2.0}},
+		{"single missing", []any{nil}, nil, []any{nil}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dl := NewDataList(tt.input...)
+			dl.FillBackward(tt.limit...)
+			assertImputeData(t, dl, tt.want)
+		})
+	}
+}
+
+func TestDataListFillWithMean(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []any
+		want  []any
+	}{
+		{"middle", []any{1.0, nil, math.NaN(), 4.0}, []any{1.0, 2.5, 2.5, 4.0}},
+		{"all missing", []any{nil, math.NaN()}, []any{nil, math.NaN()}},
+		{"none missing", []any{1.0, 2.0, 3.0}, []any{1.0, 2.0, 3.0}},
+		{"non numeric", []any{"a", nil, math.NaN()}, []any{"a", nil, math.NaN()}},
+		{"handles nil unlike FillNaNWithMean", []any{nil, 2.0, 4.0}, []any{3.0, 2.0, 4.0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dl := NewDataList(tt.input...)
+			dl.FillWithMean()
+			assertImputeData(t, dl, tt.want)
+		})
+	}
+}
+
+func TestDataListFillWithMedian(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []any
+		want  []any
+	}{
+		{"middle", []any{1.0, nil, math.NaN(), 3.0, 100.0}, []any{1.0, 3.0, 3.0, 3.0, 100.0}},
+		{"all missing", []any{nil, math.NaN()}, []any{nil, math.NaN()}},
+		{"none missing", []any{1.0, 2.0, 3.0}, []any{1.0, 2.0, 3.0}},
+		{"non numeric", []any{"a", nil, math.NaN()}, []any{"a", nil, math.NaN()}},
+		{"single observed", []any{nil, 5.0}, []any{5.0, 5.0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dl := NewDataList(tt.input...)
+			dl.FillWithMedian()
+			assertImputeData(t, dl, tt.want)
+		})
+	}
+}
+
+func TestDataListFillWithMode(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []any
+		want  []any
+	}{
+		{"strings", []any{"a", nil, "b", "a", math.NaN()}, []any{"a", "a", "b", "a", "a"}},
+		{"multiple modes first wins", []any{"b", "a", "a", "b", nil}, []any{"b", "a", "a", "b", "b"}},
+		{"all missing", []any{nil, math.NaN()}, []any{nil, math.NaN()}},
+		{"none missing", []any{"x", "y"}, []any{"x", "y"}},
+		{"single observed", []any{nil, "x"}, []any{"x", "x"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dl := NewDataList(tt.input...)
+			dl.FillWithMode()
+			assertImputeData(t, dl, tt.want)
+		})
+	}
+}
+
+func TestDataListFillByInterpolation(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []any
+		extrapolate []bool
+		want        []any
+	}{
+		{"middle", []any{1.0, math.NaN(), nil, 4.0}, nil, []any{1.0, 2.0, 3.0, 4.0}},
+		{"edges", []any{nil, 1.0, nil, 3.0, math.NaN()}, nil, []any{nil, 1.0, 2.0, 3.0, math.NaN()}},
+		{"extrapolate", []any{nil, 1.0, nil, 3.0, math.NaN()}, []bool{true}, []any{0.0, 1.0, 2.0, 3.0, 4.0}},
+		{"non numeric", []any{"a", nil, "b"}, nil, []any{"a", nil, "b"}},
+		{"all missing", []any{nil, math.NaN()}, nil, []any{nil, math.NaN()}},
+		{"none missing", []any{1.0, 2.0}, nil, []any{1.0, 2.0}},
+		{"single missing", []any{nil}, nil, []any{nil}},
+		{"single observed extrapolate", []any{nil, 5.0, math.NaN()}, []bool{true}, []any{5.0, 5.0, 5.0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dl := NewDataList(tt.input...)
+			dl.FillByInterpolation(tt.extrapolate...)
+			assertImputeData(t, dl, tt.want)
+		})
+	}
+}

--- a/datatable_impute.go
+++ b/datatable_impute.go
@@ -1,0 +1,94 @@
+package insyra
+
+func (dt *DataTable) imputeColumnIndices(methodName string, cols []string) []int {
+	if len(cols) == 0 {
+		indices := make([]int, len(dt.columns))
+		for i := range dt.columns {
+			indices[i] = i
+		}
+		return indices
+	}
+	indices := make([]int, 0, len(cols))
+	for _, col := range cols {
+		if idx, ok := dt.getColNumberByName_notAtomic(col); ok {
+			indices = append(indices, idx)
+			continue
+		}
+		if idx, ok := ParseColIndex(col); ok && idx >= 0 && idx < len(dt.columns) {
+			indices = append(indices, idx)
+			continue
+		}
+		dt.warn(methodName, "Column '%s' not found, skipping", col)
+	}
+	return indices
+}
+
+func (dt *DataTable) fillColumns(cols []string, methodName string, fill func(*DataList) bool) *DataTable {
+	dt.AtomicDo(func(dt *DataTable) {
+		for _, idx := range dt.imputeColumnIndices(methodName, cols) {
+			col := dt.columns[idx].Clone()
+			if fill(col) {
+				dt.columns[idx] = col
+			}
+		}
+		go dt.updateTimestamp()
+	})
+	return dt
+}
+
+// FillForward fills missing values in selected columns using previous observed values.
+func (dt *DataTable) FillForward(limit int, cols ...string) *DataTable {
+	return dt.fillColumns(cols, "FillForward", func(dl *DataList) bool {
+		dl.FillForward(limit)
+		return true
+	})
+}
+
+// FillBackward fills missing values in selected columns using next observed values.
+func (dt *DataTable) FillBackward(limit int, cols ...string) *DataTable {
+	return dt.fillColumns(cols, "FillBackward", func(dl *DataList) bool {
+		dl.FillBackward(limit)
+		return true
+	})
+}
+
+// FillWithMean fills missing values in numeric columns using the mean.
+func (dt *DataTable) FillWithMean(cols ...string) *DataTable {
+	return dt.fillColumns(cols, "FillWithMean", func(dl *DataList) bool {
+		if !hasOnlyNumericObservedValues(dl) {
+			return false
+		}
+		dl.FillWithMean()
+		return true
+	})
+}
+
+// FillWithMedian fills missing values in numeric columns using the median.
+func (dt *DataTable) FillWithMedian(cols ...string) *DataTable {
+	return dt.fillColumns(cols, "FillWithMedian", func(dl *DataList) bool {
+		if !hasOnlyNumericObservedValues(dl) {
+			return false
+		}
+		dl.FillWithMedian()
+		return true
+	})
+}
+
+// FillWithMode fills missing values in selected columns using the mode.
+func (dt *DataTable) FillWithMode(cols ...string) *DataTable {
+	return dt.fillColumns(cols, "FillWithMode", func(dl *DataList) bool {
+		dl.FillWithMode()
+		return true
+	})
+}
+
+// FillByInterpolation fills missing values in numeric columns by linear interpolation.
+func (dt *DataTable) FillByInterpolation(cols ...string) *DataTable {
+	return dt.fillColumns(cols, "FillByInterpolation", func(dl *DataList) bool {
+		if !hasOnlyNumericObservedValues(dl) {
+			return false
+		}
+		dl.FillByInterpolation()
+		return true
+	})
+}

--- a/datatable_impute_test.go
+++ b/datatable_impute_test.go
@@ -1,0 +1,69 @@
+package insyra
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDataTableFillForwardSpecificColumns(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(1.0, nil, 3.0).SetName("num"),
+		NewDataList("x", nil, "z").SetName("text"),
+		NewDataList(10.0, math.NaN(), 30.0).SetName("other"),
+	)
+
+	dt.FillForward(0, "num")
+
+	assertImputeData(t, dt.GetColByName("num"), []any{1.0, 1.0, 3.0})
+	assertImputeData(t, dt.GetColByName("text"), []any{"x", nil, "z"})
+	assertImputeData(t, dt.GetColByName("other"), []any{10.0, math.NaN(), 30.0})
+}
+
+func TestDataTableNumericStrategiesSkipStringColumns(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(1.0, nil, 3.0).SetName("num"),
+		NewDataList("x", nil, "z").SetName("text"),
+	)
+
+	dt.FillWithMedian()
+
+	assertImputeData(t, dt.GetColByName("num"), []any{1.0, 2.0, 3.0})
+	assertImputeData(t, dt.GetColByName("text"), []any{"x", nil, "z"})
+}
+
+func TestDataTableEmptyColumnsDefaultToAllApplicable(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(1.0, nil, 3.0).SetName("a"),
+		NewDataList(10.0, math.NaN(), 30.0).SetName("b"),
+		NewDataList("x", nil, "z").SetName("text"),
+	)
+
+	dt.FillByInterpolation()
+
+	assertImputeData(t, dt.GetColByName("a"), []any{1.0, 2.0, 3.0})
+	assertImputeData(t, dt.GetColByName("b"), []any{10.0, 20.0, 30.0})
+	assertImputeData(t, dt.GetColByName("text"), []any{"x", nil, "z"})
+}
+
+func TestDataTableFillWithMeanAndMode(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(1.0, nil, 3.0).SetName("num"),
+		NewDataList("red", nil, "red").SetName("color"),
+	)
+
+	dt.FillWithMean("num")
+	dt.FillWithMode("color")
+
+	assertImputeData(t, dt.GetColByName("num"), []any{1.0, 2.0, 3.0})
+	assertImputeData(t, dt.GetColByName("color"), []any{"red", "red", "red"})
+}
+
+func TestDataTableFillBackwardWithLimit(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(1.0, nil, math.NaN(), nil, 5.0).SetName("num"),
+	)
+
+	dt.FillBackward(2)
+
+	assertImputeData(t, dt.GetColByName("num"), []any{1.0, nil, 5.0, 5.0, 5.0})
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -45,6 +45,12 @@ type IDataList interface {
 	Normalize() *DataList
 	Standardize() *DataList
 	FillNaNWithMean() *DataList
+	FillWithMean() *DataList
+	FillForward(limit ...int) *DataList
+	FillBackward(limit ...int) *DataList
+	FillWithMedian() *DataList
+	FillWithMode() *DataList
+	FillByInterpolation(extrapolate ...bool) *DataList
 	MovingAverage(int) *DataList
 	WeightedMovingAverage(int, any) *DataList
 	ExponentialSmoothing(float64) *DataList
@@ -279,6 +285,12 @@ type IDataTable interface {
 	ReplaceNaNsWith(newValue any) *DataTable
 	ReplaceNilsWith(newValue any) *DataTable
 	ReplaceNaNsAndNilsWith(newValue any) *DataTable
+	FillForward(int, ...string) *DataTable
+	FillBackward(int, ...string) *DataTable
+	FillWithMean(...string) *DataTable
+	FillWithMedian(...string) *DataTable
+	FillWithMode(...string) *DataTable
+	FillByInterpolation(...string) *DataTable
 	ReplaceInRow(rowIndex int, oldValue, newValue any, mode ...int) *DataTable
 	ReplaceNaNsInRow(rowIndex int, newValue any, mode ...int) *DataTable
 	ReplaceNilsInRow(rowIndex int, newValue any, mode ...int) *DataTable

--- a/skills/insyra/SKILL.md
+++ b/skills/insyra/SKILL.md
@@ -104,6 +104,31 @@ func main() {
 }
 ```
 
+### 1b) Fill missing values
+
+All fill methods treat both `nil` and `math.NaN()` as missing values. The legacy `FillNaNWithMean` remains for backwards compatibility but only replaces NaN; prefer `FillWithMean` for new code. Use `ReplaceNaNsWith`, `ReplaceNilsWith`, or `ReplaceNaNsAndNilsWith` when you want constant replacement instead.
+
+```go
+dl.FillWithMean()
+dl.FillForward(limit ...int)
+dl.FillBackward(limit ...int)
+dl.FillWithMedian()
+dl.FillWithMode()
+dl.FillByInterpolation(extrapolate ...bool)
+
+dt.FillForward(limit int, cols ...string)
+dt.FillBackward(limit int, cols ...string)
+dt.FillWithMean(cols ...string)
+dt.FillWithMedian(cols ...string)
+dt.FillWithMode(cols ...string)
+dt.FillByInterpolation(cols ...string)
+```
+
+Notes:
+- `limit` uses `0` or omitted as unlimited for forward/backward fill.
+- DataTable `mean`, `median`, and `interpolation` skip non-numeric columns; `mode`, `ffill`, and `bfill` work with any selected column type.
+- `FillByInterpolation` fills gaps inside a sequence; it is distinct from `LinearInterpolation(x)`, which evaluates a y-value at a given x.
+
 ### 2) Read a CSV file into a DataTable + preview
 
 ```go

--- a/skills/use-insyra-cli/references/cli-command-guide.md
+++ b/skills/use-insyra-cli/references/cli-command-guide.md
@@ -496,10 +496,17 @@ Generated from current command registry (`insyra help`, `insyra help <command>`)
 - Usage: `expanding <var> <minobs> <reducer> [as <var>]`
 - Example: `insyra expanding pnl 1 sum as cumulative_pnl`
 
-### `fillnan`
-- Description: Fill NaN with mean
-- Usage: `fillnan <var> mean`
-- Example: `insyra fillnan x mean`
+### `fillna`
+- Description: Fill missing DataList/DataTable values
+- Usage: `fillna <var> mean|median|mode|ffill|bfill|interpolate [cols A,B,C] [limit N] [extrapolate yes|no] [missing nan|nil|both] [as <var>]`
+- Examples: `insyra fillna price median as price_filled` / `insyra fillna price ffill limit 2 missing nan as price_ffill` / `insyra fillna sales median cols revenue,cost as cleaned`
+- Notes: works on DataList or DataTable; `cols` filters DataTable columns and is ignored for DataList input; `limit` applies to `ffill`/`bfill` (`0` = unlimited); `extrapolate yes` lets interpolation fill leading/trailing gaps; `missing` selects NaN-only, nil-only, or both (default `both`); `mean`/`median`/`interpolate` skip non-numeric columns; `mode`/`ffill`/`bfill` work on any selected column type.
+
+### `fillnan` (deprecated)
+- Description: Fill NaN with mean — legacy alias
+- Usage: `fillnan <var> mean [as <var>]`
+- Example: `insyra fillnan price mean as price_filled`
+- Notes: only fills NaN (leaves nil alone) and only supports `mean`. Use `fillna <var> mean missing nan` for the same behaviour with the new command.
 
 ## Modeling / Inference / Visualization / Fetch
 ### `regression`

--- a/skills/use-insyra-cli/references/cli-command-usage.md
+++ b/skills/use-insyra-cli/references/cli-command-usage.md
@@ -190,9 +190,13 @@ This is separate from boolean-flag parsing used by option arguments like `header
 	- `quote`, `info`, `history`, `dividends`, `splits`, `actions`, `options`, `calendar`, `fastinfo`
 	- `news [count]` (default count = `10`)
 
+## `fillna`
+- Description: Fill missing DataList/DataTable values
+- Usage: `fillna <var> mean|median|mode|ffill|bfill|interpolate [cols A,B,C] [limit N] [extrapolate yes|no] [missing nan|nil|both] [as <var>]`
+
 ## `fillnan`
-- Description: Fill NaN with mean
-- Usage: `fillnan <var> mean`
+- Description: Fill NaN with mean (deprecated alias)
+- Usage: `fillnan <var> mean [as <var>]`
 
 ## `filter`
 - Description: Filter DataTable by CCL expression

--- a/skills/use-insyra-cli/references/cli-commands.md
+++ b/skills/use-insyra-cli/references/cli-commands.md
@@ -124,7 +124,8 @@ This list is generated from `insyra help` in this repository state.
 - `cummin` - Running minimum (historical low)
 - `rolling` - Rolling-window reduction (sum/mean/min/max/median/std/var)
 - `expanding` - Expanding-window reduction (sum/mean/min/max/median/std/var)
-- `fillnan` - Fill NaN with mean
+- `fillna` - Fill missing DataList/DataTable values (mean/median/mode/ffill/bfill/interpolate)
+- `fillnan` - Fill NaN with mean (deprecated alias)
 
 ## Modeling / Inference / Visualization / Fetch
 - `regression` - Regression analysis: linear/poly/exp/log/logistic/poisson
@@ -144,3 +145,15 @@ This list is generated from `insyra help` in this repository state.
 - `chisq` - Chi-square test commands
 - `plot` - Create charts from variables
 - `fetch` - Fetch external data
+
+## Missing-Value Fill Commands
+
+- `fillna <var> mean|median|mode|ffill|bfill|interpolate [cols A,B,C] [limit N] [extrapolate yes|no] [missing nan|nil|both] [as <var>]`
+  - Works on either a DataList or a DataTable; saves a cloned result to `as <var>` or `$result`.
+  - `cols` filters which DataTable columns to fill (omitted = all applicable); ignored for DataList input.
+  - `limit` applies to `ffill` and `bfill`; `0` means unlimited.
+  - `extrapolate yes` lets interpolation fill leading/trailing numeric gaps.
+  - `missing` selects which kind of missing to fill: `nan`, `nil`, or `both` (default `both`).
+  - `mean`, `median`, and `interpolate` skip non-numeric columns; `mode`, `ffill`, and `bfill` can fill any selected column type.
+- `fillnan <var> mean [as <var>]`
+  - Deprecated alias kept for backward compatibility. Only fills NaN (leaves nil alone) and only supports `mean`. Use `fillna <var> mean missing nan` instead.


### PR DESCRIPTION
Closes #165.

## Summary

- **DataList**: new `FillForward`, `FillBackward`, `FillWithMean`, `FillWithMedian`, `FillWithMode`, `FillByInterpolation` methods. All treat NaN + nil uniformly as missing.
- **DataTable**: column-wise versions of the same methods; numeric strategies skip non-numeric columns automatically.
- **CLI**: new `fillna` command unifies DataList/DataTable imputation with `cols`/`limit`/`extrapolate`/`missing` options. The legacy `fillnan <var> mean` is kept as a deprecated alias that only fills NaN (`FillNaNWithMean` semantics) and now prints a warning pointing users at `fillna`.
- **`missing nan|nil|both`** (CLI): default `both`. NaN-only / nil-only modes are implemented via a CLI-layer snapshot/restore so the Go API stays simple.
- Existing `FillNaNWithMean`, `ReplaceNaNsWith`, `ReplaceNilsWith`, `ReplaceNaNsAndNilsWith`, and `LinearInterpolation(x)` are unchanged.
- Docs (`Docs/DataList.md`, `Docs/DataTable.md`, `Docs/cli-dsl.md`) and skills (`skills/insyra/SKILL.md`, `skills/use-insyra-cli/references/*`) updated.

## Design notes

- No `MissingMode` bitmask on the Go API — would have required `variadic` conflict with `limit` and 99% of calls want `both`. The CLI-layer `missing` option covers the rare case without polluting the API.
- KNN imputation is intentionally out of scope; it should live in `stats/` alongside `stats.KNNClassification`/`stats.KNNRegression` and is filed as future work.
- No `isr` wrappers added — `*isr.dl` / `*isr.dt` embed the root types, so method promotion already exposes the new methods.

## Test plan

- [x] `go test ./...` green
- [x] `go build ./...` clean
- [x] `insyra help fillna` / `insyra help fillnan` show expected output
- [x] Unit tests cover: middle / leading / trailing / all-missing / no-missing / limit boundaries / extrapolate on-off / non-numeric handling / `missing nan` preserves nil / `missing nil` preserves NaN / table column filtering / legacy `fillnan` deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)