### PR TITLE
Add DataTable categorical encoding

### DIFF
--- a/Docs/DataTable.md
+++ b/Docs/DataTable.md
@@ -11,6 +11,7 @@ DataTable is the core data structure of Insyra for handling structured data. It 
 - [Data Operations](#data-operations)
   - [Merge](#merge)
   - [GroupBy](#groupby)
+  - [Categorical Encoding](#categorical-encoding)
 - [Data Replacement](#data-replacement)
 - [Column Calculation](#column-calculation)
 - [Searching](#searching)
@@ -886,6 +887,164 @@ long, err := dt.Unpivot(insyra.UnpivotConfig{
 ```
 
 **Relationship to `GroupBy + Aggregate`:** `Pivot` is essentially `GroupBy(Index..., Columns).Aggregate(Values, AggFunc)` followed by spreading the `Columns` key out into headers. When you only need the grouped summary (one row per key, no header spreading), use `GroupBy + Aggregate` directly — it is simpler and produces the same intermediate structure.
+
+### Categorical Encoding
+
+```go
+func (dt *DataTable) OneHotEncode(opts OneHotOptions) (*DataTable, *OneHotEncoder, error)
+func (dt *DataTable) LabelEncode(opts LabelEncodeOptions) (*DataTable, *LabelEncoder, error)
+func (dt *DataTable) OrdinalEncode(opts OrdinalEncodeOptions) (*DataTable, *OrdinalEncoder, error)
+```
+
+**Description:** Categorical encoding turns string or mixed-type category columns into numeric columns that can feed `stats.LinearRegression`, KNN, PCA, and clustering. Each method returns a fresh `*DataTable`; the receiver is not modified. The returned encoder stores the fitted category mapping and can `Transform` another table with the same schema, such as a test set or prediction batch.
+
+Column references are resolved by column name first, then Excel-style index (`"A"`, `"B"`, ..., `"AA"`). Category identity uses both type and value, so `int(1)` and string `"1"` are distinct. Missing means `nil` or `NaN`.
+
+**Policies:**
+
+| Type | Values | Behavior |
+|---|---|---|
+| `NaNPolicy` | `NaNAsCategory`, `NaNError`, `NaNSkip` | Missing becomes its own category, errors, or is skipped (`nil` for label/ordinal; all-zero for one-hot). |
+| `UnknownPolicy` | `UnknownIgnore`, `UnknownError`, `UnknownAsNew` | On `Transform`, unseen categories become all-zero/`nil`, error, or extend the encoder. |
+| `LabelSort` | `LabelSortFirstSeen`, `LabelSortLexicographic`, `LabelSortByFrequency` | Controls label id assignment order. |
+
+**Options:**
+
+```go
+type OneHotOptions struct {
+    Columns        []string
+    DropFirst      bool
+    HandleNaN      NaNPolicy
+    Unknown        UnknownPolicy
+    Prefix         string
+    Separator      string
+    KeepOriginal   bool
+    SortCategories bool
+}
+
+type LabelEncodeOptions struct {
+    Column       string
+    NewColumn    string
+    SortBy       LabelSort
+    HandleNaN    NaNPolicy
+    Unknown      UnknownPolicy
+    KeepOriginal bool
+}
+
+type OrdinalEncodeOptions struct {
+    Column       string
+    Order        []any
+    NewColumn    string
+    HandleNaN    NaNPolicy
+    Unknown      UnknownPolicy
+    KeepOriginal bool
+}
+```
+
+`OneHotEncode` emits one `0/1` `int` column per category, named `<prefix><separator><category>`; by default the prefix is the source column name and the separator is `"_"`. `DropFirst` omits the first category as the reference level. `LabelEncode` maps each class to an integer id. `OrdinalEncode` uses the explicit `Order` slice as `0..n-1`.
+
+**Encoder interface and introspection:**
+
+```go
+type Encoder interface {
+    Transform(dt *DataTable) (*DataTable, error)
+    InverseTransform(dt *DataTable) (*DataTable, error)
+    Kind() string
+}
+
+func (e *OneHotEncoder) Categories() map[string][]any
+func (e *OneHotEncoder) OutputColumns() []string
+func (e *LabelEncoder) Classes() []any
+func (e *LabelEncoder) Inverse(values ...any) ([]any, error)
+func (e *OrdinalEncoder) Classes() []any
+func (e *OrdinalEncoder) Inverse(values ...any) ([]any, error)
+```
+
+**Example — fit, transform, inverse:**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/HazelnutParadise/insyra"
+)
+
+func main() {
+    train := insyra.NewDataTable(
+        insyra.NewDataList("red", "blue", "red").SetName("color"),
+        insyra.NewDataList(10, 20, 30).SetName("value"),
+    )
+
+    encoded, enc, err := train.OneHotEncode(insyra.OneHotOptions{
+        Columns:   []string{"color"},
+        DropFirst: true,
+        Unknown:   insyra.UnknownIgnore,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(encoded.ColNames()) // [color_blue value]
+
+    test := insyra.NewDataTable(
+        insyra.NewDataList("blue", "green").SetName("color"),
+        insyra.NewDataList(40, 50).SetName("value"),
+    )
+    encodedTest, err := enc.Transform(test)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(encodedTest.GetColByName("color_blue").Data()) // [1 0]
+
+    originalShape, err := enc.InverseTransform(encoded)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(originalShape.ColNames()) // [color value]
+}
+```
+
+**Example — categorical predictor into `stats.LinearRegression`:**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/HazelnutParadise/insyra"
+    "github.com/HazelnutParadise/insyra/stats"
+)
+
+func main() {
+    dt := insyra.NewDataTable(
+        insyra.NewDataList(100.0, 130.0, 110.0, 150.0).SetName("sales"),
+        insyra.NewDataList("basic", "pro", "basic", "pro").SetName("plan"),
+    )
+
+    x, _, err := dt.OneHotEncode(insyra.OneHotOptions{
+        Columns:   []string{"plan"},
+        DropFirst: true, // baseline = first-seen category ("basic")
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fit, err := stats.LinearRegression(
+        dt.GetColByName("sales"),
+        x.GetColByName("plan_pro"),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(fit.Coefficients) // intercept, effect of plan_pro
+}
+```
 
 ### Window / sequence transforms (Shift / Diff / PctChange / Cum\* / Rolling / Expanding)
 

--- a/Docs/cli-dsl.md
+++ b/Docs/cli-dsl.md
@@ -408,6 +408,24 @@ unpivot survey idvars id valuevars Q1,Q2,Q3 varname question valuename score as 
 show long
 ```
 
+### B4. Categorical encoding
+
+`encode` does one-shot categorical encoding for DataTable variables: it fits on the input table, writes the encoded table to `as <var>` or `$result`, and does not persist encoder state across CLI commands. Use the Go API when you need train/test reuse with `Transform`.
+
+```text
+encode <var> onehot <col1[,col2,...]> [dropfirst true|false] [keeporiginal true|false] [nan category|error|skip] [unknown ignore|error|new] [prefix <p>] [sep <s>] [sortcats true|false] [as <var>]
+encode <var> label <col> [newcol <name>] [sortby firstseen|lex|freq] [nan category|error|skip] [unknown ignore|error|new] [keeporiginal true|false] [as <var>]
+encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]
+```
+
+Examples:
+
+```text
+encode sales onehot region,channel dropfirst true as x
+encode sales label segment newcol segment_id sortby freq keeporiginal true as labeled
+encode survey ordinal satisfaction order low,medium,high unknown error as ranked
+```
+
 ### C. Go `engine/dsl` session flow
 
 ```go
@@ -447,7 +465,7 @@ High-level command map:
 - **Data IO / Creation**: `newdl`, `newdt`, `load`, `read`, `save`, `convert`
 - **Database**: `db` (`connect` / `list` / `tables` / `disconnect`), `load sql`, `save <var> sql`
 - **DataTable Structure / Access**: `addcol`, `addrow`, `dropcol`, `droprow`, `swap`, `transpose`, `rows`, `cols`, `row`, `col`, `get`, `set`, `setrownames`, `setcolnames`
-- **Data Processing**: `filter`, `sort`, `sample`, `find`, `replace`, `clean`, `fillna`, `merge`, `groupby`, `pivot`, `unpivot`, `ccl`, `addcolccl`
+- **Data Processing**: `filter`, `sort`, `sample`, `find`, `replace`, `clean`, `fillna`, `merge`, `groupby`, `pivot`, `unpivot`, `encode`, `ccl`, `addcolccl`
 - **DataList Stats**: `sum`, `mean`, `median`, `mode`, `stdev`, `var`, `min`, `max`, `range`, `quartile`, `iqr`, `percentile`, `count`, `counter`, `corr`, `cov`, `corrmatrix`, `skewness`, `kurtosis`
 - **Time Series / Transforms**: `rank`, `normalize`, `standardize`, `reverse`, `upper`, `lower`, `capitalize`, `parsenums`, `parsestrings`, `movavg`, `expsmooth`, `diff`, `diffn`, `shift`, `pctchange`, `cumsum`, `cumprod`, `cummax`, `cummin`, `rolling`, `expanding`, `fillna`
 - **Modeling / Viz / Fetch**: `regression`, `pca`, `kmeans`, `hclust`, `cutree`, `dbscan`, `silhouette`, `knn_classify`, `knn_regress`, `knn_neighbors`, `ttest`, `ztest`, `anova`, `ftest`, `chisq`, `plot`, `fetch`
@@ -511,6 +529,7 @@ Source policy:
 | `drop` | `drop <var>` | Delete variable |
 | `dropcol` | `dropcol <var> <name\|index...>` | Drop columns by name or index |
 | `droprow` | `droprow <var> <index\|name...>` | Drop rows by index or name |
+| `encode` | `encode <var> onehot\|label\|ordinal ... [as <var>]` | One-shot categorical encoding for DataTable variables |
 | `env` | `env <create\|list\|open\|clear\|export\|import\|delete\|rename\|info> [args]` | Environment management |
 | `exit` | `exit` | Exit REPL |
 | `expanding` | `expanding <var> <minobs> <reducer> [as <var>]` | Expanding-window reduction (reducer: sum\|mean\|min\|max\|median\|std\|var) |

--- a/cli/commands/encode.go
+++ b/cli/commands/encode.go
@@ -1,0 +1,362 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	insyra "github.com/HazelnutParadise/insyra"
+)
+
+func init() {
+	_ = Register(&CommandHandler{
+		Name:        "encode",
+		Usage:       "encode <var> onehot|label|ordinal ... [as <var>]",
+		Description: "One-shot categorical encoding for DataTable variables (encoder state is not persisted)",
+		Forms: []string{
+			"encode <var> onehot <col1[,col2,...]> [dropfirst true|false] [keeporiginal true|false] [nan category|error|skip] [unknown ignore|error|new] [prefix <p>] [sep <s>] [sortcats true|false] [as <var>]",
+			"encode <var> label <col> [newcol <name>] [sortby firstseen|lex|freq] [nan category|error|skip] [unknown ignore|error|new] [keeporiginal true|false] [as <var>]",
+			"encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]",
+		},
+		Examples: []string{
+			"insyra encode sales onehot region,channel dropfirst true as x",
+			"insyra encode sales label segment newcol segment_id sortby freq keeporiginal true as labeled",
+			"insyra encode survey ordinal satisfaction order low,medium,high unknown error as ranked",
+		},
+		Run: runEncodeCommand,
+	})
+}
+
+func runEncodeCommand(ctx *ExecContext, args []string) error {
+	coreArgs, alias := parseAlias(args)
+	if len(coreArgs) < 3 {
+		return fmt.Errorf("usage: encode <var> onehot|label|ordinal ... [as <var>]")
+	}
+	table, err := getDataTableVar(ctx, coreArgs[0])
+	if err != nil {
+		return err
+	}
+	mode := strings.ToLower(coreArgs[1])
+	var result *insyra.DataTable
+	switch mode {
+	case "onehot":
+		opts, err := parseOneHotEncodeOptions(coreArgs[2:])
+		if err != nil {
+			return err
+		}
+		result, _, err = table.OneHotEncode(opts)
+		if err != nil {
+			return err
+		}
+	case "label":
+		opts, err := parseLabelEncodeOptions(coreArgs[2:])
+		if err != nil {
+			return err
+		}
+		result, _, err = table.LabelEncode(opts)
+		if err != nil {
+			return err
+		}
+	case "ordinal":
+		opts, err := parseOrdinalEncodeOptions(coreArgs[2:])
+		if err != nil {
+			return err
+		}
+		result, _, err = table.OrdinalEncode(opts)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("encode: unknown mode %q (supported: onehot, label, ordinal)", coreArgs[1])
+	}
+	ctx.Vars[alias] = result
+	_, _ = fmt.Fprintf(ctx.Output, "encoded into %s (%d rows, %d cols)\n", alias, result.NumRows(), result.NumCols())
+	return nil
+}
+
+func parseOneHotEncodeOptions(args []string) (insyra.OneHotOptions, error) {
+	var opts insyra.OneHotOptions
+	if len(args) == 0 {
+		return opts, fmt.Errorf("encode onehot: columns are required")
+	}
+	opts.Columns = parseCSVTokens(args[0])
+	if len(opts.Columns) == 0 {
+		return opts, fmt.Errorf("encode onehot: columns are required")
+	}
+	for i := 1; i < len(args); {
+		key := strings.ToLower(args[i])
+		next := func() (string, error) {
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("encode onehot: option %q requires a value", args[i])
+			}
+			return args[i+1], nil
+		}
+		switch key {
+		case "dropfirst":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			b, err := parseFlexBool(v)
+			if err != nil {
+				return opts, fmt.Errorf("encode onehot: invalid value for dropfirst: %w", err)
+			}
+			opts.DropFirst = b
+			i += 2
+		case "keeporiginal":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			b, err := parseFlexBool(v)
+			if err != nil {
+				return opts, fmt.Errorf("encode onehot: invalid value for keeporiginal: %w", err)
+			}
+			opts.KeepOriginal = b
+			i += 2
+		case "nan":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			policy, err := parseEncodeNaNPolicy(v, "encode onehot")
+			if err != nil {
+				return opts, err
+			}
+			opts.HandleNaN = policy
+			i += 2
+		case "unknown":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			policy, err := parseEncodeUnknownPolicy(v, "encode onehot", true)
+			if err != nil {
+				return opts, err
+			}
+			opts.Unknown = policy
+			i += 2
+		case "prefix":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			opts.Prefix = v
+			i += 2
+		case "sep":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			opts.Separator = v
+			i += 2
+		case "sortcats":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			b, err := parseFlexBool(v)
+			if err != nil {
+				return opts, fmt.Errorf("encode onehot: invalid value for sortcats: %w", err)
+			}
+			opts.SortCategories = b
+			i += 2
+		default:
+			return opts, fmt.Errorf("encode onehot: unknown option %q (supported: dropfirst, keeporiginal, nan, unknown, prefix, sep, sortcats)", args[i])
+		}
+	}
+	return opts, nil
+}
+
+func parseLabelEncodeOptions(args []string) (insyra.LabelEncodeOptions, error) {
+	var opts insyra.LabelEncodeOptions
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return opts, fmt.Errorf("encode label: column is required")
+	}
+	opts.Column = args[0]
+	for i := 1; i < len(args); {
+		key := strings.ToLower(args[i])
+		next := func() (string, error) {
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("encode label: option %q requires a value", args[i])
+			}
+			return args[i+1], nil
+		}
+		switch key {
+		case "newcol":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			opts.NewColumn = v
+			i += 2
+		case "sortby":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			sortBy, err := parseEncodeLabelSort(v)
+			if err != nil {
+				return opts, err
+			}
+			opts.SortBy = sortBy
+			i += 2
+		case "nan":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			policy, err := parseEncodeNaNPolicy(v, "encode label")
+			if err != nil {
+				return opts, err
+			}
+			opts.HandleNaN = policy
+			i += 2
+		case "unknown":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			policy, err := parseEncodeUnknownPolicy(v, "encode label", true)
+			if err != nil {
+				return opts, err
+			}
+			opts.Unknown = policy
+			i += 2
+		case "keeporiginal":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			b, err := parseFlexBool(v)
+			if err != nil {
+				return opts, fmt.Errorf("encode label: invalid value for keeporiginal: %w", err)
+			}
+			opts.KeepOriginal = b
+			i += 2
+		default:
+			return opts, fmt.Errorf("encode label: unknown option %q (supported: newcol, sortby, nan, unknown, keeporiginal)", args[i])
+		}
+	}
+	return opts, nil
+}
+
+func parseOrdinalEncodeOptions(args []string) (insyra.OrdinalEncodeOptions, error) {
+	var opts insyra.OrdinalEncodeOptions
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return opts, fmt.Errorf("encode ordinal: column is required")
+	}
+	opts.Column = args[0]
+	for i := 1; i < len(args); {
+		key := strings.ToLower(args[i])
+		next := func() (string, error) {
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("encode ordinal: option %q requires a value", args[i])
+			}
+			return args[i+1], nil
+		}
+		switch key {
+		case "order":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			tokens := parseCSVTokens(v)
+			if len(tokens) == 0 {
+				return opts, fmt.Errorf("encode ordinal: order requires at least one value")
+			}
+			opts.Order = make([]any, 0, len(tokens))
+			for _, token := range tokens {
+				opts.Order = append(opts.Order, parseLiteral(token))
+			}
+			i += 2
+		case "newcol":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			opts.NewColumn = v
+			i += 2
+		case "unknown":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			policy, err := parseEncodeUnknownPolicy(v, "encode ordinal", false)
+			if err != nil {
+				return opts, err
+			}
+			opts.Unknown = policy
+			i += 2
+		case "nan":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			policy, err := parseEncodeNaNPolicy(v, "encode ordinal")
+			if err != nil {
+				return opts, err
+			}
+			opts.HandleNaN = policy
+			i += 2
+		case "keeporiginal":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			b, err := parseFlexBool(v)
+			if err != nil {
+				return opts, fmt.Errorf("encode ordinal: invalid value for keeporiginal: %w", err)
+			}
+			opts.KeepOriginal = b
+			i += 2
+		default:
+			return opts, fmt.Errorf("encode ordinal: unknown option %q (supported: order, newcol, unknown, nan, keeporiginal)", args[i])
+		}
+	}
+	if len(opts.Order) == 0 {
+		return opts, fmt.Errorf("encode ordinal: order is required (use 'order <v1,v2,...>')")
+	}
+	return opts, nil
+}
+
+func parseEncodeNaNPolicy(raw, context string) (insyra.NaNPolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "category":
+		return insyra.NaNAsCategory, nil
+	case "error":
+		return insyra.NaNError, nil
+	case "skip":
+		return insyra.NaNSkip, nil
+	}
+	return insyra.NaNAsCategory, fmt.Errorf("%s: invalid value for nan %q (supported: category, error, skip)", context, raw)
+}
+
+func parseEncodeUnknownPolicy(raw, context string, allowNew bool) (insyra.UnknownPolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "ignore":
+		return insyra.UnknownIgnore, nil
+	case "error":
+		return insyra.UnknownError, nil
+	case "new":
+		if allowNew {
+			return insyra.UnknownAsNew, nil
+		}
+	}
+	supported := "ignore, error"
+	if allowNew {
+		supported = "ignore, error, new"
+	}
+	return insyra.UnknownIgnore, fmt.Errorf("%s: invalid value for unknown %q (supported: %s)", context, raw, supported)
+}
+
+func parseEncodeLabelSort(raw string) (insyra.LabelSort, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "firstseen":
+		return insyra.LabelSortFirstSeen, nil
+	case "lex":
+		return insyra.LabelSortLexicographic, nil
+	case "freq":
+		return insyra.LabelSortByFrequency, nil
+	}
+	return insyra.LabelSortFirstSeen, fmt.Errorf("encode label: invalid value for sortby %q (supported: firstseen, lex, freq)", raw)
+}

--- a/cli/commands/encode_test.go
+++ b/cli/commands/encode_test.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	insyra "github.com/HazelnutParadise/insyra"
+)
+
+func encodeCommandTestTable() *insyra.DataTable {
+	return insyra.NewDataTable(
+		insyra.NewDataList("red", "blue", "red").SetName("color"),
+		insyra.NewDataList("S", "M", "S").SetName("size"),
+		insyra.NewDataList(10, 20, 30).SetName("value"),
+	)
+}
+
+func assertEncodeCommandData(t *testing.T, dl *insyra.DataList, want []any) {
+	t.Helper()
+	if dl == nil {
+		t.Fatalf("got nil DataList")
+	}
+	if got := dl.Data(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("data = %#v, want %#v", got, want)
+	}
+}
+
+func TestRunEncodeCommandOneHot(t *testing.T) {
+	ctx := newTestExecContext(t)
+	ctx.Vars["sales"] = encodeCommandTestTable()
+	err := runEncodeCommand(ctx, []string{
+		"sales",
+		"onehot",
+		"color",
+		"dropfirst", "true",
+		"as", "x",
+	})
+	if err != nil {
+		t.Fatalf("runEncodeCommand onehot failed: %v", err)
+	}
+	got, ok := ctx.Vars["x"].(*insyra.DataTable)
+	if !ok {
+		t.Fatalf("expected DataTable, got %T", ctx.Vars["x"])
+	}
+	if cols := got.ColNames(); !reflect.DeepEqual(cols, []string{"color_blue", "size", "value"}) {
+		t.Fatalf("columns = %#v", cols)
+	}
+	assertEncodeCommandData(t, got.GetColByName("color_blue"), []any{0, 1, 0})
+}
+
+func TestRunEncodeCommandLabel(t *testing.T) {
+	ctx := newTestExecContext(t)
+	ctx.Vars["sales"] = encodeCommandTestTable()
+	err := runEncodeCommand(ctx, []string{
+		"sales",
+		"label",
+		"color",
+		"newcol", "color_id",
+		"sortby", "lex",
+		"keeporiginal", "true",
+		"as", "labeled",
+	})
+	if err != nil {
+		t.Fatalf("runEncodeCommand label failed: %v", err)
+	}
+	got := ctx.Vars["labeled"].(*insyra.DataTable)
+	if cols := got.ColNames(); !reflect.DeepEqual(cols, []string{"color", "color_id", "size", "value"}) {
+		t.Fatalf("columns = %#v", cols)
+	}
+	assertEncodeCommandData(t, got.GetColByName("color_id"), []any{1, 0, 1})
+}
+
+func TestRunEncodeCommandOrdinal(t *testing.T) {
+	ctx := newTestExecContext(t)
+	ctx.Vars["sales"] = encodeCommandTestTable()
+	err := runEncodeCommand(ctx, []string{
+		"sales",
+		"ordinal",
+		"size",
+		"order", "S,M,L",
+		"newcol", "size_rank",
+		"unknown", "error",
+		"as", "ranked",
+	})
+	if err != nil {
+		t.Fatalf("runEncodeCommand ordinal failed: %v", err)
+	}
+	got := ctx.Vars["ranked"].(*insyra.DataTable)
+	if cols := got.ColNames(); !reflect.DeepEqual(cols, []string{"color", "size_rank", "value"}) {
+		t.Fatalf("columns = %#v", cols)
+	}
+	assertEncodeCommandData(t, got.GetColByName("size_rank"), []any{0, 1, 0})
+}
+
+func TestRunEncodeCommandErrors(t *testing.T) {
+	ctx := newTestExecContext(t)
+	ctx.Vars["sales"] = encodeCommandTestTable()
+	if err := runEncodeCommand(ctx, []string{"sales", "onehot", "color", "bogus", "x"}); err == nil || !strings.Contains(err.Error(), "unknown option") {
+		t.Fatalf("expected unknown option error, got %v", err)
+	}
+	if err := runEncodeCommand(ctx, []string{"sales", "label", "color", "sortby", "bad"}); err == nil || !strings.Contains(err.Error(), "invalid value for sortby") {
+		t.Fatalf("expected bad sortby error, got %v", err)
+	}
+	if err := runEncodeCommand(ctx, []string{"sales", "ordinal", "size", "order", "S,M", "unknown", "new"}); err == nil || !strings.Contains(err.Error(), "invalid value for unknown") {
+		t.Fatalf("expected bad ordinal unknown error, got %v", err)
+	}
+	if err := runEncodeCommand(ctx, []string{"sales", "onehot", "color", "nan", "bad"}); err == nil || !strings.Contains(err.Error(), "invalid value for nan") {
+		t.Fatalf("expected bad nan error, got %v", err)
+	}
+}

--- a/datatable_encode.go
+++ b/datatable_encode.go
@@ -1,0 +1,1100 @@
+package insyra
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// NaNPolicy controls how missing (nil or NaN) source values are encoded.
+type NaNPolicy int
+
+const (
+	// NaNAsCategory makes missing values their own category.
+	NaNAsCategory NaNPolicy = iota
+	// NaNError returns an error when a missing value is present.
+	NaNError
+	// NaNSkip skips missing values in the encoded output.
+	NaNSkip
+)
+
+// UnknownPolicy controls unseen categories encountered during Transform.
+type UnknownPolicy int
+
+const (
+	// UnknownIgnore emits all-zero indicators or nil cells for unseen values.
+	UnknownIgnore UnknownPolicy = iota
+	// UnknownError returns an error for the first unseen value.
+	UnknownError
+	// UnknownAsNew extends the encoder with unseen values.
+	UnknownAsNew
+)
+
+// LabelSort controls id assignment order for LabelEncode.
+type LabelSort int
+
+const (
+	// LabelSortFirstSeen assigns ids in first-appearance order.
+	LabelSortFirstSeen LabelSort = iota
+	// LabelSortLexicographic assigns ids by sorted string form.
+	LabelSortLexicographic
+	// LabelSortByFrequency assigns ids by descending frequency.
+	LabelSortByFrequency
+)
+
+// OneHotOptions configures DataTable one-hot encoding.
+type OneHotOptions struct {
+	Columns        []string
+	DropFirst      bool
+	HandleNaN      NaNPolicy
+	Unknown        UnknownPolicy
+	Prefix         string
+	Separator      string
+	KeepOriginal   bool
+	SortCategories bool
+}
+
+// LabelEncodeOptions configures DataTable label encoding.
+type LabelEncodeOptions struct {
+	Column       string
+	NewColumn    string
+	SortBy       LabelSort
+	HandleNaN    NaNPolicy
+	Unknown      UnknownPolicy
+	KeepOriginal bool
+}
+
+// OrdinalEncodeOptions configures DataTable ordinal encoding.
+type OrdinalEncodeOptions struct {
+	Column       string
+	Order        []any
+	NewColumn    string
+	HandleNaN    NaNPolicy
+	Unknown      UnknownPolicy
+	KeepOriginal bool
+}
+
+// Encoder is the minimal shared surface for fitted categorical encoders.
+type Encoder interface {
+	Transform(dt *DataTable) (*DataTable, error)
+	InverseTransform(dt *DataTable) (*DataTable, error)
+	Kind() string
+}
+
+// OneHotEncoder stores fitted one-hot category mappings.
+type OneHotEncoder struct {
+	opts          OneHotOptions
+	columns       []oneHotColumnState
+	outputColumns []string
+}
+
+type oneHotColumnState struct {
+	sourceRef     string
+	sourceName    string
+	sourceIndex   int
+	prefix        string
+	categories    []any
+	keyToIndex    map[string]int
+	outputColumns []string
+}
+
+// LabelEncoder stores a fitted label encoding.
+type LabelEncoder struct {
+	opts        LabelEncodeOptions
+	sourceRef   string
+	sourceName  string
+	encodedName string
+	classes     []any
+	keyToID     map[string]int
+}
+
+// OrdinalEncoder stores a fitted ordinal encoding.
+type OrdinalEncoder struct {
+	opts        OrdinalEncodeOptions
+	sourceRef   string
+	sourceName  string
+	encodedName string
+	classes     []any
+	keyToID     map[string]int
+}
+
+// OneHotEncode fits one-hot indicators for selected columns and returns a new table.
+func (dt *DataTable) OneHotEncode(opts OneHotOptions) (*DataTable, *OneHotEncoder, error) {
+	enc, err := fitOneHotEncoder(dt, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	out, err := enc.Transform(dt)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, enc, nil
+}
+
+// LabelEncode fits integer ids for a column and returns a new table.
+func (dt *DataTable) LabelEncode(opts LabelEncodeOptions) (*DataTable, *LabelEncoder, error) {
+	enc, err := fitLabelEncoder(dt, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	out, err := enc.Transform(dt)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, enc, nil
+}
+
+// OrdinalEncode fits explicit ordered ids for a column and returns a new table.
+func (dt *DataTable) OrdinalEncode(opts OrdinalEncodeOptions) (*DataTable, *OrdinalEncoder, error) {
+	enc, err := fitOrdinalEncoder(dt, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	out, err := enc.Transform(dt)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, enc, nil
+}
+
+// Transform applies this fitted one-hot encoder to a new table.
+func (e *OneHotEncoder) Transform(dt *DataTable) (*DataTable, error) {
+	if e == nil {
+		return nil, fmt.Errorf("OneHotEncoder.Transform: encoder is nil")
+	}
+	out := NewDataTable()
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		var cols []*DataList
+		cols, err = e.transformNotAtomic(t)
+		if err != nil {
+			return
+		}
+		out.AppendCols(cols...)
+		copyRowNamesNotAtomic(out, t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// InverseTransform rebuilds source columns from one-hot indicators.
+func (e *OneHotEncoder) InverseTransform(dt *DataTable) (*DataTable, error) {
+	if e == nil {
+		return nil, fmt.Errorf("OneHotEncoder.InverseTransform: encoder is nil")
+	}
+	out := NewDataTable()
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		var cols []*DataList
+		cols, err = e.inverseTransformNotAtomic(t)
+		if err != nil {
+			return
+		}
+		out.AppendCols(cols...)
+		copyRowNamesNotAtomic(out, t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Kind returns the encoder family name.
+func (e *OneHotEncoder) Kind() string { return "onehot" }
+
+// Categories returns source-column categories in encoded order.
+func (e *OneHotEncoder) Categories() map[string][]any {
+	out := make(map[string][]any, len(e.columns))
+	for _, col := range e.columns {
+		out[col.sourceName] = append([]any(nil), col.categories...)
+	}
+	return out
+}
+
+// OutputColumns returns generated indicator column names.
+func (e *OneHotEncoder) OutputColumns() []string {
+	return append([]string(nil), e.outputColumns...)
+}
+
+// Transform applies this fitted label encoder to a new table.
+func (e *LabelEncoder) Transform(dt *DataTable) (*DataTable, error) {
+	if e == nil {
+		return nil, fmt.Errorf("LabelEncoder.Transform: encoder is nil")
+	}
+	return transformScalarEncoder(dt, e.sourceRef, e.sourceName, e.encodedName, e.opts.NewColumn != "", e.opts.KeepOriginal, func(v any) (any, error) {
+		return e.encodeValue(v)
+	})
+}
+
+// InverseTransform decodes the label column back to its source values.
+func (e *LabelEncoder) InverseTransform(dt *DataTable) (*DataTable, error) {
+	if e == nil {
+		return nil, fmt.Errorf("LabelEncoder.InverseTransform: encoder is nil")
+	}
+	return inverseScalarEncoder(dt, e.sourceName, e.encodedName, e.opts.NewColumn != "", e.opts.KeepOriginal, func(v any) (any, error) {
+		return e.inverseOne(v)
+	})
+}
+
+// Kind returns the encoder family name.
+func (e *LabelEncoder) Kind() string { return "label" }
+
+// Classes returns category values by id.
+func (e *LabelEncoder) Classes() []any {
+	return append([]any(nil), e.classes...)
+}
+
+// Inverse maps label ids back to category values.
+func (e *LabelEncoder) Inverse(values ...any) ([]any, error) {
+	return inverseIDs(values, e.inverseOne)
+}
+
+// Transform applies this fitted ordinal encoder to a new table.
+func (e *OrdinalEncoder) Transform(dt *DataTable) (*DataTable, error) {
+	if e == nil {
+		return nil, fmt.Errorf("OrdinalEncoder.Transform: encoder is nil")
+	}
+	return transformScalarEncoder(dt, e.sourceRef, e.sourceName, e.encodedName, e.opts.NewColumn != "", e.opts.KeepOriginal, func(v any) (any, error) {
+		return e.encodeValue(v)
+	})
+}
+
+// InverseTransform decodes the ordinal column back to its source values.
+func (e *OrdinalEncoder) InverseTransform(dt *DataTable) (*DataTable, error) {
+	if e == nil {
+		return nil, fmt.Errorf("OrdinalEncoder.InverseTransform: encoder is nil")
+	}
+	return inverseScalarEncoder(dt, e.sourceName, e.encodedName, e.opts.NewColumn != "", e.opts.KeepOriginal, func(v any) (any, error) {
+		return e.inverseOne(v)
+	})
+}
+
+// Kind returns the encoder family name.
+func (e *OrdinalEncoder) Kind() string { return "ordinal" }
+
+// Classes returns category values by id.
+func (e *OrdinalEncoder) Classes() []any {
+	return append([]any(nil), e.classes...)
+}
+
+// Inverse maps ordinal ids back to category values.
+func (e *OrdinalEncoder) Inverse(values ...any) ([]any, error) {
+	return inverseIDs(values, e.inverseOne)
+}
+
+func fitOneHotEncoder(dt *DataTable, opts OneHotOptions) (*OneHotEncoder, error) {
+	opts = normalizeOneHotOptions(opts)
+	if len(opts.Columns) == 0 {
+		return nil, fmt.Errorf("OneHotEncode: Columns requires at least one column")
+	}
+
+	enc := &OneHotEncoder{opts: opts}
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		seenCols := map[int]struct{}{}
+		for _, ref := range opts.Columns {
+			idx, label, ok := resolveEncodingColumn(t, ref)
+			if !ok {
+				err = fmt.Errorf("OneHotEncode: column %q not found", ref)
+				return
+			}
+			if _, exists := seenCols[idx]; exists {
+				err = fmt.Errorf("OneHotEncode: column %q listed more than once", ref)
+				return
+			}
+			seenCols[idx] = struct{}{}
+			prefix := opts.Prefix
+			if prefix == "" {
+				prefix = label
+			}
+			state := oneHotColumnState{
+				sourceRef:   label,
+				sourceName:  label,
+				sourceIndex: idx,
+				prefix:      prefix,
+				keyToIndex:  map[string]int{},
+			}
+			if t.columns[idx].name != "" {
+				state.sourceName = t.columns[idx].name
+				state.sourceRef = t.columns[idx].name
+			}
+			if err = collectOneHotCategories(&state, t.columns[idx].data, opts); err != nil {
+				return
+			}
+			if opts.SortCategories {
+				sortCategoriesByString(state.categories, state.keyToIndex)
+			}
+			state.outputColumns = oneHotOutputNames(state, opts)
+			enc.columns = append(enc.columns, state)
+			enc.outputColumns = append(enc.outputColumns, state.outputColumns...)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return enc, nil
+}
+
+func fitLabelEncoder(dt *DataTable, opts LabelEncodeOptions) (*LabelEncoder, error) {
+	if strings.TrimSpace(opts.Column) == "" {
+		return nil, fmt.Errorf("LabelEncode: Column is required")
+	}
+	enc := &LabelEncoder{opts: opts}
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		idx, label, ok := resolveEncodingColumn(t, opts.Column)
+		if !ok {
+			err = fmt.Errorf("LabelEncode: column %q not found", opts.Column)
+			return
+		}
+		enc.sourceRef = label
+		enc.sourceName = label
+		if t.columns[idx].name != "" {
+			enc.sourceRef = t.columns[idx].name
+			enc.sourceName = t.columns[idx].name
+		}
+		enc.encodedName = enc.sourceName
+		if opts.NewColumn != "" {
+			enc.encodedName = opts.NewColumn
+		}
+		enc.classes, enc.keyToID, err = collectLabelClasses(t.columns[idx].data, opts)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return enc, nil
+}
+
+func fitOrdinalEncoder(dt *DataTable, opts OrdinalEncodeOptions) (*OrdinalEncoder, error) {
+	if strings.TrimSpace(opts.Column) == "" {
+		return nil, fmt.Errorf("OrdinalEncode: Column is required")
+	}
+	if len(opts.Order) == 0 {
+		return nil, fmt.Errorf("OrdinalEncode: Order requires at least one category")
+	}
+	enc := &OrdinalEncoder{opts: opts}
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		idx, label, ok := resolveEncodingColumn(t, opts.Column)
+		if !ok {
+			err = fmt.Errorf("OrdinalEncode: column %q not found", opts.Column)
+			return
+		}
+		enc.sourceRef = label
+		enc.sourceName = label
+		if t.columns[idx].name != "" {
+			enc.sourceRef = t.columns[idx].name
+			enc.sourceName = t.columns[idx].name
+		}
+		enc.encodedName = enc.sourceName
+		if opts.NewColumn != "" {
+			enc.encodedName = opts.NewColumn
+		}
+		enc.classes, enc.keyToID, err = collectOrdinalClasses(t.columns[idx].data, opts)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return enc, nil
+}
+
+func collectOneHotCategories(state *oneHotColumnState, values []any, opts OneHotOptions) error {
+	for _, raw := range values {
+		v, skip, err := normalizeCategoryValue(raw, opts.HandleNaN, "OneHotEncode")
+		if err != nil {
+			return err
+		}
+		if skip {
+			continue
+		}
+		addCategory(&state.categories, state.keyToIndex, v)
+	}
+	return nil
+}
+
+func collectLabelClasses(values []any, opts LabelEncodeOptions) ([]any, map[string]int, error) {
+	type info struct {
+		value     any
+		firstSeen int
+		count     int
+	}
+	infos := map[string]*info{}
+	order := []string{}
+	for _, raw := range values {
+		v, skip, err := normalizeCategoryValue(raw, opts.HandleNaN, "LabelEncode")
+		if err != nil {
+			return nil, nil, err
+		}
+		if skip {
+			continue
+		}
+		key := labelKey(v)
+		if existing, ok := infos[key]; ok {
+			existing.count++
+			continue
+		}
+		infos[key] = &info{value: v, firstSeen: len(order), count: 1}
+		order = append(order, key)
+	}
+	switch opts.SortBy {
+	case LabelSortFirstSeen:
+	case LabelSortLexicographic:
+		sort.SliceStable(order, func(i, j int) bool {
+			return fmt.Sprint(infos[order[i]].value) < fmt.Sprint(infos[order[j]].value)
+		})
+	case LabelSortByFrequency:
+		sort.SliceStable(order, func(i, j int) bool {
+			a, b := infos[order[i]], infos[order[j]]
+			if a.count != b.count {
+				return a.count > b.count
+			}
+			return a.firstSeen < b.firstSeen
+		})
+	default:
+		return nil, nil, fmt.Errorf("LabelEncode: unknown LabelSort %d", opts.SortBy)
+	}
+	classes := make([]any, 0, len(order))
+	keyToID := make(map[string]int, len(order))
+	for _, key := range order {
+		keyToID[key] = len(classes)
+		classes = append(classes, infos[key].value)
+	}
+	return classes, keyToID, nil
+}
+
+func collectOrdinalClasses(values []any, opts OrdinalEncodeOptions) ([]any, map[string]int, error) {
+	classes := []any{}
+	keyToID := map[string]int{}
+	for _, raw := range opts.Order {
+		v := raw
+		if isNilOrNaN(v) {
+			switch opts.HandleNaN {
+			case NaNError:
+				return nil, nil, fmt.Errorf("OrdinalEncode: Order contains missing value")
+			case NaNSkip, NaNAsCategory:
+				v = nil
+			}
+		}
+		if !addCategory(&classes, keyToID, v) {
+			return nil, nil, fmt.Errorf("OrdinalEncode: duplicate category %v in Order", raw)
+		}
+	}
+	for _, raw := range values {
+		v, skip, err := normalizeCategoryValue(raw, opts.HandleNaN, "OrdinalEncode")
+		if err != nil {
+			return nil, nil, err
+		}
+		if skip {
+			continue
+		}
+		key := labelKey(v)
+		if _, ok := keyToID[key]; ok {
+			continue
+		}
+		if opts.HandleNaN == NaNAsCategory && v == nil {
+			addCategory(&classes, keyToID, nil)
+			continue
+		}
+		switch opts.Unknown {
+		case UnknownIgnore:
+			continue
+		case UnknownAsNew:
+			addCategory(&classes, keyToID, v)
+		case UnknownError:
+			return nil, nil, fmt.Errorf("OrdinalEncode: value %v is not in Order", raw)
+		default:
+			return nil, nil, fmt.Errorf("OrdinalEncode: unknown UnknownPolicy %d", opts.Unknown)
+		}
+	}
+	return classes, keyToID, nil
+}
+
+func (e *OneHotEncoder) transformNotAtomic(t *DataTable) ([]*DataList, error) {
+	stateByIndex := map[int]*oneHotColumnState{}
+	for i := range e.columns {
+		idx, _, ok := resolveEncodingColumn(t, e.columns[i].sourceRef)
+		if !ok {
+			return nil, fmt.Errorf("OneHotEncoder.Transform: column %q not found", e.columns[i].sourceRef)
+		}
+		stateByIndex[idx] = &e.columns[i]
+	}
+
+	outCols := []*DataList{}
+	for idx, col := range t.columns {
+		state, encoded := stateByIndex[idx]
+		if !encoded {
+			outCols = append(outCols, col.Clone())
+			continue
+		}
+		if e.opts.KeepOriginal {
+			outCols = append(outCols, col.Clone())
+		}
+		encodedCols, err := e.encodeOneHotColumn(state, col.data)
+		if err != nil {
+			return nil, err
+		}
+		outCols = append(outCols, encodedCols...)
+	}
+	e.refreshOutputColumns()
+	if err := rejectDuplicateOutputNames(outCols, "OneHotEncoder.Transform"); err != nil {
+		return nil, err
+	}
+	return outCols, nil
+}
+
+func (e *OneHotEncoder) encodeOneHotColumn(state *oneHotColumnState, values []any) ([]*DataList, error) {
+	start := 0
+	if e.opts.DropFirst && len(state.categories) > 0 {
+		start = 1
+	}
+	for _, raw := range values {
+		v, skip, err := normalizeCategoryValue(raw, e.opts.HandleNaN, "OneHotEncoder.Transform")
+		if err != nil {
+			return nil, err
+		}
+		if skip {
+			continue
+		}
+		key := labelKey(v)
+		if _, ok := state.keyToIndex[key]; ok {
+			continue
+		}
+		switch e.opts.Unknown {
+		case UnknownIgnore:
+		case UnknownError:
+			return nil, fmt.Errorf("OneHotEncoder.Transform: unknown category %v", raw)
+		case UnknownAsNew:
+			state.keyToIndex[key] = len(state.categories)
+			state.categories = append(state.categories, v)
+			name := oneHotCategoryColumnName(state.prefix, e.opts.Separator, v)
+			state.outputColumns = append(state.outputColumns, name)
+		default:
+			return nil, fmt.Errorf("OneHotEncoder.Transform: unknown UnknownPolicy %d", e.opts.Unknown)
+		}
+	}
+
+	cols := make([]*DataList, 0, len(state.categories)-start)
+	for _, name := range state.outputColumns {
+		cols = append(cols, NewDataList().SetName(name))
+	}
+	for _, raw := range values {
+		row := make([]int, len(cols))
+		v, skip, err := normalizeCategoryValue(raw, e.opts.HandleNaN, "OneHotEncoder.Transform")
+		if err != nil {
+			return nil, err
+		}
+		if !skip {
+			if id, ok := state.keyToIndex[labelKey(v)]; ok && id >= start {
+				row[id-start] = 1
+			}
+		}
+		for i, value := range row {
+			cols[i].Append(value)
+		}
+	}
+	return cols, nil
+}
+
+func (e *OneHotEncoder) inverseTransformNotAtomic(t *DataTable) ([]*DataList, error) {
+	generated := map[string]struct{}{}
+	insertions := map[int][]*oneHotColumnState{}
+	for i := range e.columns {
+		state := &e.columns[i]
+		if e.opts.KeepOriginal {
+			if idx, _, ok := resolveEncodingColumn(t, state.sourceRef); ok {
+				for _, name := range state.outputColumns {
+					generated[name] = struct{}{}
+				}
+				_ = idx
+				continue
+			}
+		}
+		first := -1
+		for _, name := range state.outputColumns {
+			idx, _, ok := resolveEncodingColumn(t, name)
+			if ok && (first < 0 || idx < first) {
+				first = idx
+			}
+			generated[name] = struct{}{}
+		}
+		if first >= 0 {
+			insertions[first] = append(insertions[first], state)
+			continue
+		}
+		if len(state.outputColumns) == 0 {
+			insertAt := state.sourceIndex
+			if insertAt < 0 {
+				insertAt = 0
+			}
+			if insertAt > len(t.columns) {
+				insertAt = len(t.columns)
+			}
+			insertions[insertAt] = append(insertions[insertAt], state)
+		}
+	}
+
+	outCols := []*DataList{}
+	for idx, col := range t.columns {
+		if states, ok := insertions[idx]; ok {
+			for _, state := range states {
+				decoded, err := e.decodeOneHotColumn(t, state)
+				if err != nil {
+					return nil, err
+				}
+				outCols = append(outCols, decoded)
+			}
+		}
+		if _, isGenerated := generated[col.name]; isGenerated {
+			continue
+		}
+		outCols = append(outCols, col.Clone())
+	}
+	if states, ok := insertions[len(t.columns)]; ok {
+		for _, state := range states {
+			decoded, err := e.decodeOneHotColumn(t, state)
+			if err != nil {
+				return nil, err
+			}
+			outCols = append(outCols, decoded)
+		}
+	}
+	if err := rejectDuplicateOutputNames(outCols, "OneHotEncoder.InverseTransform"); err != nil {
+		return nil, err
+	}
+	return outCols, nil
+}
+
+func (e *OneHotEncoder) decodeOneHotColumn(t *DataTable, state *oneHotColumnState) (*DataList, error) {
+	nRows := t.getMaxColLength()
+	out := NewDataList()
+	out.SetName(state.sourceName)
+	start := 0
+	if e.opts.DropFirst && len(state.categories) > 0 {
+		start = 1
+	}
+	indicatorCols := make([]*DataList, len(state.outputColumns))
+	for i, name := range state.outputColumns {
+		idx, _, ok := resolveEncodingColumn(t, name)
+		if !ok {
+			return nil, fmt.Errorf("OneHotEncoder.InverseTransform: indicator column %q not found", name)
+		}
+		indicatorCols[i] = t.columns[idx]
+	}
+	for row := 0; row < nRows; row++ {
+		found := -1
+		for j, col := range indicatorCols {
+			if row >= len(col.data) {
+				continue
+			}
+			if isOne(col.data[row]) {
+				found = j + start
+				break
+			}
+		}
+		if found >= 0 && found < len(state.categories) {
+			out.Append(state.categories[found])
+			continue
+		}
+		if e.opts.DropFirst && len(state.categories) > 0 {
+			out.Append(state.categories[0])
+			continue
+		}
+		if e.opts.HandleNaN == NaNError {
+			return nil, fmt.Errorf("OneHotEncoder.InverseTransform: all-zero row %d", row)
+		}
+		out.Append(nil)
+	}
+	return out, nil
+}
+
+func (e *LabelEncoder) encodeValue(raw any) (any, error) {
+	v, skip, err := normalizeCategoryValue(raw, e.opts.HandleNaN, "LabelEncoder.Transform")
+	if err != nil {
+		return nil, err
+	}
+	if skip {
+		return nil, nil
+	}
+	key := labelKey(v)
+	if id, ok := e.keyToID[key]; ok {
+		return id, nil
+	}
+	switch e.opts.Unknown {
+	case UnknownIgnore:
+		return nil, nil
+	case UnknownError:
+		return nil, fmt.Errorf("LabelEncoder.Transform: unknown category %v", raw)
+	case UnknownAsNew:
+		id := len(e.classes)
+		e.classes = append(e.classes, v)
+		e.keyToID[key] = id
+		return id, nil
+	default:
+		return nil, fmt.Errorf("LabelEncoder.Transform: unknown UnknownPolicy %d", e.opts.Unknown)
+	}
+}
+
+func (e *LabelEncoder) inverseOne(v any) (any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	id, ok := integerID(v)
+	if !ok {
+		return nil, fmt.Errorf("LabelEncoder.Inverse: invalid id %v", v)
+	}
+	if id < 0 || id >= len(e.classes) {
+		return nil, fmt.Errorf("LabelEncoder.Inverse: id %d out of range", id)
+	}
+	return e.classes[id], nil
+}
+
+func (e *OrdinalEncoder) encodeValue(raw any) (any, error) {
+	v, skip, err := normalizeCategoryValue(raw, e.opts.HandleNaN, "OrdinalEncoder.Transform")
+	if err != nil {
+		return nil, err
+	}
+	if skip {
+		return nil, nil
+	}
+	key := labelKey(v)
+	if id, ok := e.keyToID[key]; ok {
+		return id, nil
+	}
+	switch e.opts.Unknown {
+	case UnknownIgnore:
+		return nil, nil
+	case UnknownError:
+		return nil, fmt.Errorf("OrdinalEncoder.Transform: unknown category %v", raw)
+	case UnknownAsNew:
+		id := len(e.classes)
+		e.classes = append(e.classes, v)
+		e.keyToID[key] = id
+		return id, nil
+	default:
+		return nil, fmt.Errorf("OrdinalEncoder.Transform: unknown UnknownPolicy %d", e.opts.Unknown)
+	}
+}
+
+func (e *OrdinalEncoder) inverseOne(v any) (any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	id, ok := integerID(v)
+	if !ok {
+		return nil, fmt.Errorf("OrdinalEncoder.Inverse: invalid id %v", v)
+	}
+	if id < 0 || id >= len(e.classes) {
+		return nil, fmt.Errorf("OrdinalEncoder.Inverse: id %d out of range", id)
+	}
+	return e.classes[id], nil
+}
+
+func transformScalarEncoder(dt *DataTable, sourceRef, sourceName, encodedName string, hasNewColumn, keepOriginal bool, encode func(any) (any, error)) (*DataTable, error) {
+	out := NewDataTable()
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		idx, _, ok := resolveEncodingColumn(t, sourceRef)
+		if !ok {
+			err = fmt.Errorf("encoder Transform: column %q not found", sourceRef)
+			return
+		}
+		outCols := []*DataList{}
+		for colIdx, col := range t.columns {
+			if colIdx != idx {
+				outCols = append(outCols, col.Clone())
+				continue
+			}
+			encoded := NewDataList()
+			if hasNewColumn {
+				encoded.SetName(encodedName)
+				if keepOriginal {
+					outCols = append(outCols, col.Clone(), encoded)
+				} else {
+					outCols = append(outCols, encoded)
+				}
+			} else {
+				encoded.SetName(sourceName)
+				outCols = append(outCols, encoded)
+			}
+			for _, v := range col.data {
+				got, encErr := encode(v)
+				if encErr != nil {
+					err = encErr
+					return
+				}
+				encoded.Append(got)
+			}
+		}
+		if err != nil {
+			return
+		}
+		if dupErr := rejectDuplicateOutputNames(outCols, "encoder Transform"); dupErr != nil {
+			err = dupErr
+			return
+		}
+		out.AppendCols(outCols...)
+		copyRowNamesNotAtomic(out, t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func inverseScalarEncoder(dt *DataTable, sourceName, encodedName string, hasNewColumn, keepOriginal bool, decode func(any) (any, error)) (*DataTable, error) {
+	out := NewDataTable()
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		encodedIdx, _, ok := resolveEncodingColumn(t, encodedName)
+		if !ok {
+			err = fmt.Errorf("encoder InverseTransform: column %q not found", encodedName)
+			return
+		}
+		_, sourceExists := t.getColNumberByName_notAtomic(sourceName)
+		outCols := []*DataList{}
+		for idx, col := range t.columns {
+			if hasNewColumn && keepOriginal && sourceExists {
+				if idx == encodedIdx {
+					continue
+				}
+				outCols = append(outCols, col.Clone())
+				continue
+			}
+			if idx != encodedIdx {
+				if hasNewColumn && col.name == sourceName {
+					continue
+				}
+				outCols = append(outCols, col.Clone())
+				continue
+			}
+			decoded := NewDataList()
+			decoded.SetName(sourceName)
+			for _, v := range col.data {
+				got, decErr := decode(v)
+				if decErr != nil {
+					err = decErr
+					return
+				}
+				decoded.Append(got)
+			}
+			outCols = append(outCols, decoded)
+		}
+		if err != nil {
+			return
+		}
+		if dupErr := rejectDuplicateOutputNames(outCols, "encoder InverseTransform"); dupErr != nil {
+			err = dupErr
+			return
+		}
+		out.AppendCols(outCols...)
+		copyRowNamesNotAtomic(out, t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func normalizeOneHotOptions(opts OneHotOptions) OneHotOptions {
+	if opts.Separator == "" {
+		opts.Separator = "_"
+	}
+	return opts
+}
+
+func resolveEncodingColumn(dt *DataTable, ref string) (int, string, bool) {
+	if idx, ok := dt.getColNumberByName_notAtomic(ref); ok {
+		label := dt.columns[idx].name
+		if label == "" {
+			label = fallbackEncodingColumnName(idx)
+		}
+		return idx, label, true
+	}
+	if idx, ok := ParseColIndex(ref); ok && idx >= 0 && idx < len(dt.columns) {
+		label := dt.columns[idx].name
+		if label == "" {
+			label = fallbackEncodingColumnName(idx)
+		}
+		return idx, label, true
+	}
+	return -1, "", false
+}
+
+func fallbackEncodingColumnName(idx int) string {
+	if name, ok := alphaColIndex(idx); ok {
+		return name
+	}
+	return fmt.Sprintf("col_%d", idx)
+}
+
+func normalizeCategoryValue(v any, policy NaNPolicy, method string) (any, bool, error) {
+	if !isNilOrNaN(v) {
+		return v, false, nil
+	}
+	switch policy {
+	case NaNAsCategory:
+		return nil, false, nil
+	case NaNError:
+		return nil, false, fmt.Errorf("%s: missing value found", method)
+	case NaNSkip:
+		return nil, true, nil
+	default:
+		return nil, false, fmt.Errorf("%s: unknown NaNPolicy %d", method, policy)
+	}
+}
+
+func addCategory(classes *[]any, keyToID map[string]int, v any) bool {
+	key := labelKey(v)
+	if _, ok := keyToID[key]; ok {
+		return false
+	}
+	keyToID[key] = len(*classes)
+	*classes = append(*classes, v)
+	return true
+}
+
+func sortCategoriesByString(classes []any, keyToID map[string]int) {
+	firstSeen := map[string]int{}
+	for i, v := range classes {
+		firstSeen[labelKey(v)] = i
+	}
+	sort.SliceStable(classes, func(i, j int) bool {
+		a, b := fmt.Sprint(classes[i]), fmt.Sprint(classes[j])
+		if a != b {
+			return a < b
+		}
+		return firstSeen[labelKey(classes[i])] < firstSeen[labelKey(classes[j])]
+	})
+	for k := range keyToID {
+		delete(keyToID, k)
+	}
+	for i, v := range classes {
+		keyToID[labelKey(v)] = i
+	}
+}
+
+func oneHotOutputNames(state oneHotColumnState, opts OneHotOptions) []string {
+	start := 0
+	if opts.DropFirst && len(state.categories) > 0 {
+		start = 1
+	}
+	names := make([]string, 0, len(state.categories)-start)
+	for _, v := range state.categories[start:] {
+		names = append(names, oneHotCategoryColumnName(state.prefix, opts.Separator, v))
+	}
+	return names
+}
+
+func oneHotCategoryColumnName(prefix, sep string, v any) string {
+	if sep == "" {
+		sep = "_"
+	}
+	return prefix + sep + fmt.Sprint(v)
+}
+
+func (e *OneHotEncoder) refreshOutputColumns() {
+	e.outputColumns = e.outputColumns[:0]
+	for _, col := range e.columns {
+		e.outputColumns = append(e.outputColumns, col.outputColumns...)
+	}
+}
+
+func labelKey(v any) string {
+	return fmt.Sprintf("%T:%#v", v, v)
+}
+
+func copyRowNamesNotAtomic(out, src *DataTable) {
+	if src.rowNames != nil {
+		out.rowNames = src.rowNames.Clone()
+	}
+}
+
+func rejectDuplicateOutputNames(cols []*DataList, method string) error {
+	seen := map[string]struct{}{}
+	for _, col := range cols {
+		name := col.name
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("%s: duplicate output column name %q", method, name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+func isOne(v any) bool {
+	if v == nil {
+		return false
+	}
+	if f, ok := ToFloat64Safe(v); ok {
+		return f == 1
+	}
+	return false
+}
+
+func integerID(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int8:
+		return int(n), true
+	case int16:
+		return int(n), true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case uint:
+		return int(n), true
+	case uint8:
+		return int(n), true
+	case uint16:
+		return int(n), true
+	case uint32:
+		return int(n), true
+	case uint64:
+		return int(n), true
+	case float32:
+		f := float64(n)
+		i := int(f)
+		return i, f == float64(i)
+	case float64:
+		i := int(n)
+		return i, n == float64(i)
+	default:
+		return 0, false
+	}
+}
+
+func inverseIDs(values []any, inverse func(any) (any, error)) ([]any, error) {
+	flat := flattenInverseArgs(values)
+	out := make([]any, 0, len(flat))
+	for _, v := range flat {
+		got, err := inverse(v)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, got)
+	}
+	return out, nil
+}
+
+func flattenInverseArgs(values []any) []any {
+	if len(values) != 1 || values[0] == nil {
+		return values
+	}
+	rv := reflect.ValueOf(values[0])
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return values
+	}
+	out := make([]any, 0, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		out = append(out, rv.Index(i).Interface())
+	}
+	return out
+}

--- a/datatable_encode_test.go
+++ b/datatable_encode_test.go
@@ -1,0 +1,403 @@
+package insyra
+
+import (
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func encodeTestTable() *DataTable {
+	return NewDataTable(
+		NewDataList("red", "blue", "red").SetName("color"),
+		NewDataList("S", "M", "S").SetName("size"),
+		NewDataList(10, 20, 30).SetName("value"),
+	)
+}
+
+func assertEncodeData(t *testing.T, dl *DataList, want []any) {
+	t.Helper()
+	if dl == nil {
+		t.Fatalf("got nil DataList")
+	}
+	got := dl.Data()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("data = %#v, want %#v", got, want)
+	}
+}
+
+func assertEncodeCols(t *testing.T, dt *DataTable, want []string) {
+	t.Helper()
+	got := dt.ColNames()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("columns = %#v, want %#v", got, want)
+	}
+}
+
+func TestOneHotEncodeBasicDropFirstKeepOriginalAndInverse(t *testing.T) {
+	dt := encodeTestTable()
+	out, enc, err := dt.OneHotEncode(OneHotOptions{Columns: []string{"color"}})
+	if err != nil {
+		t.Fatalf("OneHotEncode failed: %v", err)
+	}
+	assertEncodeCols(t, out, []string{"color_red", "color_blue", "size", "value"})
+	assertEncodeData(t, out.GetColByName("color_red"), []any{1, 0, 1})
+	assertEncodeData(t, out.GetColByName("color_blue"), []any{0, 1, 0})
+
+	roundTrip, err := enc.InverseTransform(out)
+	if err != nil {
+		t.Fatalf("InverseTransform failed: %v", err)
+	}
+	assertEncodeCols(t, roundTrip, []string{"color", "size", "value"})
+	assertEncodeData(t, roundTrip.GetColByName("color"), []any{"red", "blue", "red"})
+
+	dropped, encDrop, err := dt.OneHotEncode(OneHotOptions{Columns: []string{"color"}, DropFirst: true, KeepOriginal: true})
+	if err != nil {
+		t.Fatalf("DropFirst OneHotEncode failed: %v", err)
+	}
+	assertEncodeCols(t, dropped, []string{"color", "color_blue", "size", "value"})
+	assertEncodeData(t, dropped.GetColByName("color_blue"), []any{0, 1, 0})
+	if got := encDrop.OutputColumns(); !reflect.DeepEqual(got, []string{"color_blue"}) {
+		t.Fatalf("OutputColumns = %#v", got)
+	}
+	restored, err := encDrop.InverseTransform(dropped)
+	if err != nil {
+		t.Fatalf("DropFirst inverse failed: %v", err)
+	}
+	assertEncodeCols(t, restored, []string{"color", "size", "value"})
+}
+
+func TestOneHotEncodeMultiColumnPrefixSeparatorAndSort(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList("b", "a").SetName("color"),
+		NewDataList("S", "M").SetName("size"),
+		NewDataList(1, 2).SetName("value"),
+	)
+	out, enc, err := dt.OneHotEncode(OneHotOptions{
+		Columns:        []string{"color", "size"},
+		Prefix:         "cat",
+		Separator:      "__",
+		SortCategories: true,
+	})
+	if err != nil {
+		t.Fatalf("OneHotEncode failed: %v", err)
+	}
+	assertEncodeCols(t, out, []string{"cat__a", "cat__b", "cat__M", "cat__S", "value"})
+	assertEncodeData(t, out.GetColByName("cat__a"), []any{0, 1})
+	assertEncodeData(t, out.GetColByName("cat__b"), []any{1, 0})
+	gotCats := enc.Categories()
+	if !reflect.DeepEqual(gotCats["color"], []any{"a", "b"}) {
+		t.Fatalf("color categories = %#v", gotCats["color"])
+	}
+}
+
+func TestOneHotTransformUnknownPolicies(t *testing.T) {
+	train := NewDataTable(NewDataList("red", "blue").SetName("color"))
+	test := NewDataTable(NewDataList("green").SetName("color"))
+
+	_, ignoreEnc, err := train.OneHotEncode(OneHotOptions{Columns: []string{"color"}, Unknown: UnknownIgnore})
+	if err != nil {
+		t.Fatalf("fit ignore encoder: %v", err)
+	}
+	ignored, err := ignoreEnc.Transform(test)
+	if err != nil {
+		t.Fatalf("ignore transform failed: %v", err)
+	}
+	assertEncodeData(t, ignored.GetColByName("color_red"), []any{0})
+	assertEncodeData(t, ignored.GetColByName("color_blue"), []any{0})
+
+	_, errorEnc, err := train.OneHotEncode(OneHotOptions{Columns: []string{"color"}, Unknown: UnknownError})
+	if err != nil {
+		t.Fatalf("fit error encoder: %v", err)
+	}
+	if _, err := errorEnc.Transform(test); err == nil {
+		t.Fatalf("expected unknown-category error")
+	}
+
+	_, newEnc, err := train.OneHotEncode(OneHotOptions{Columns: []string{"color"}, Unknown: UnknownAsNew})
+	if err != nil {
+		t.Fatalf("fit new encoder: %v", err)
+	}
+	extended, err := newEnc.Transform(test)
+	if err != nil {
+		t.Fatalf("new transform failed: %v", err)
+	}
+	assertEncodeCols(t, extended, []string{"color_red", "color_blue", "color_green"})
+	assertEncodeData(t, extended.GetColByName("color_green"), []any{1})
+}
+
+func TestOneHotNaNPoliciesEmptyAndSingleCategory(t *testing.T) {
+	withMissing := NewDataTable(
+		NewDataList(1, 2, 3).SetName("id"),
+		NewDataList("red", nil, "blue").SetName("color"),
+	)
+	asCategory, enc, err := withMissing.OneHotEncode(OneHotOptions{Columns: []string{"color"}, HandleNaN: NaNAsCategory})
+	if err != nil {
+		t.Fatalf("NaNAsCategory failed: %v", err)
+	}
+	assertEncodeCols(t, asCategory, []string{"id", "color_red", "color_<nil>", "color_blue"})
+	assertEncodeData(t, asCategory.GetColByName("color_<nil>"), []any{0, 1, 0})
+	roundTrip, err := enc.InverseTransform(asCategory)
+	if err != nil {
+		t.Fatalf("inverse missing category: %v", err)
+	}
+	assertEncodeData(t, roundTrip.GetColByName("color"), []any{"red", nil, "blue"})
+
+	skipped, _, err := withMissing.OneHotEncode(OneHotOptions{Columns: []string{"color"}, HandleNaN: NaNSkip})
+	if err != nil {
+		t.Fatalf("NaNSkip failed: %v", err)
+	}
+	assertEncodeData(t, skipped.GetColByName("color_red"), []any{1, 0, 0})
+	assertEncodeData(t, skipped.GetColByName("color_blue"), []any{0, 0, 1})
+
+	if _, _, err := withMissing.OneHotEncode(OneHotOptions{Columns: []string{"color"}, HandleNaN: NaNError}); err == nil {
+		t.Fatalf("expected NaNError to fail")
+	}
+	if _, _, err := NewDataTable(NewDataList(math.NaN()).SetName("x")).OneHotEncode(OneHotOptions{Columns: []string{"x"}, HandleNaN: NaNError}); err == nil {
+		t.Fatalf("expected NaNError to catch NaN")
+	}
+
+	empty := NewDataTable(NewDataList().SetName("color"))
+	emptyOut, _, err := empty.OneHotEncode(OneHotOptions{Columns: []string{"color"}})
+	if err != nil {
+		t.Fatalf("empty column failed: %v", err)
+	}
+	if emptyOut.NumRows() != 0 || emptyOut.NumCols() != 0 {
+		t.Fatalf("empty one-hot size = %dx%d", emptyOut.NumRows(), emptyOut.NumCols())
+	}
+
+	single := NewDataTable(
+		NewDataList(1, 2).SetName("id"),
+		NewDataList("red", "red").SetName("color"),
+	)
+	singleOut, singleEnc, err := single.OneHotEncode(OneHotOptions{Columns: []string{"color"}, DropFirst: true})
+	if err != nil {
+		t.Fatalf("single-category DropFirst failed: %v", err)
+	}
+	assertEncodeCols(t, singleOut, []string{"id"})
+	singleBack, err := singleEnc.InverseTransform(singleOut)
+	if err != nil {
+		t.Fatalf("single-category inverse failed: %v", err)
+	}
+	assertEncodeCols(t, singleBack, []string{"id", "color"})
+	assertEncodeData(t, singleBack.GetColByName("color"), []any{"red", "red"})
+}
+
+func TestLabelEncodeSortNewColumnKeepOriginalInverseAndIdentity(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList("b", "a", "b").SetName("label"),
+		NewDataList(1, 2, 3).SetName("value"),
+	)
+	firstSeen, enc, err := dt.LabelEncode(LabelEncodeOptions{Column: "label"})
+	if err != nil {
+		t.Fatalf("LabelEncode failed: %v", err)
+	}
+	assertEncodeCols(t, firstSeen, []string{"label", "value"})
+	assertEncodeData(t, firstSeen.GetColByName("label"), []any{0, 1, 0})
+	if got := enc.Classes(); !reflect.DeepEqual(got, []any{"b", "a"}) {
+		t.Fatalf("classes = %#v", got)
+	}
+	if inv, err := enc.Inverse(0, 1, 0); err != nil || !reflect.DeepEqual(inv, []any{"b", "a", "b"}) {
+		t.Fatalf("Inverse variadic = %#v, %v", inv, err)
+	}
+	if inv, err := enc.Inverse([]int{1, 0}); err != nil || !reflect.DeepEqual(inv, []any{"a", "b"}) {
+		t.Fatalf("Inverse slice = %#v, %v", inv, err)
+	}
+	roundTrip, err := enc.InverseTransform(firstSeen)
+	if err != nil {
+		t.Fatalf("label inverse transform: %v", err)
+	}
+	assertEncodeData(t, roundTrip.GetColByName("label"), []any{"b", "a", "b"})
+
+	lex, _, err := dt.LabelEncode(LabelEncodeOptions{Column: "label", NewColumn: "label_id", SortBy: LabelSortLexicographic})
+	if err != nil {
+		t.Fatalf("lex LabelEncode failed: %v", err)
+	}
+	assertEncodeCols(t, lex, []string{"label_id", "value"})
+	assertEncodeData(t, lex.GetColByName("label_id"), []any{1, 0, 1})
+
+	freqSrc := NewDataTable(NewDataList("b", "a", "a", "b", "a").SetName("label"))
+	freq, _, err := freqSrc.LabelEncode(LabelEncodeOptions{Column: "label", SortBy: LabelSortByFrequency})
+	if err != nil {
+		t.Fatalf("freq LabelEncode failed: %v", err)
+	}
+	assertEncodeData(t, freq.GetColByName("label"), []any{1, 0, 0, 1, 0})
+
+	kept, _, err := dt.LabelEncode(LabelEncodeOptions{Column: "label", NewColumn: "label_id", KeepOriginal: true})
+	if err != nil {
+		t.Fatalf("keep LabelEncode failed: %v", err)
+	}
+	assertEncodeCols(t, kept, []string{"label", "label_id", "value"})
+
+	typed, typedEnc, err := NewDataTable(NewDataList(1, "1").SetName("mixed")).LabelEncode(LabelEncodeOptions{Column: "mixed"})
+	if err != nil {
+		t.Fatalf("typed LabelEncode failed: %v", err)
+	}
+	assertEncodeData(t, typed.GetColByName("mixed"), []any{0, 1})
+	if got := typedEnc.Classes(); !reflect.DeepEqual(got, []any{1, "1"}) {
+		t.Fatalf("typed classes = %#v", got)
+	}
+}
+
+func TestLabelTransformUnknownAndNaNPolicies(t *testing.T) {
+	train := NewDataTable(NewDataList("red", "blue").SetName("color"))
+	test := NewDataTable(NewDataList("green").SetName("color"))
+
+	_, ignoreEnc, err := train.LabelEncode(LabelEncodeOptions{Column: "color", Unknown: UnknownIgnore})
+	if err != nil {
+		t.Fatalf("fit ignore label: %v", err)
+	}
+	ignored, err := ignoreEnc.Transform(test)
+	if err != nil {
+		t.Fatalf("label ignore transform: %v", err)
+	}
+	assertEncodeData(t, ignored.GetColByName("color"), []any{nil})
+
+	_, errorEnc, err := train.LabelEncode(LabelEncodeOptions{Column: "color", Unknown: UnknownError})
+	if err != nil {
+		t.Fatalf("fit error label: %v", err)
+	}
+	if _, err := errorEnc.Transform(test); err == nil {
+		t.Fatalf("expected label unknown error")
+	}
+
+	_, newEnc, err := train.LabelEncode(LabelEncodeOptions{Column: "color", Unknown: UnknownAsNew})
+	if err != nil {
+		t.Fatalf("fit new label: %v", err)
+	}
+	extended, err := newEnc.Transform(test)
+	if err != nil {
+		t.Fatalf("label new transform: %v", err)
+	}
+	assertEncodeData(t, extended.GetColByName("color"), []any{2})
+
+	missing := NewDataTable(NewDataList("red", nil).SetName("color"))
+	asCategory, _, err := missing.LabelEncode(LabelEncodeOptions{Column: "color", HandleNaN: NaNAsCategory})
+	if err != nil {
+		t.Fatalf("label NaNAsCategory: %v", err)
+	}
+	assertEncodeData(t, asCategory.GetColByName("color"), []any{0, 1})
+	skipped, _, err := missing.LabelEncode(LabelEncodeOptions{Column: "color", HandleNaN: NaNSkip})
+	if err != nil {
+		t.Fatalf("label NaNSkip: %v", err)
+	}
+	assertEncodeData(t, skipped.GetColByName("color"), []any{0, nil})
+	if _, _, err := missing.LabelEncode(LabelEncodeOptions{Column: "color", HandleNaN: NaNError}); err == nil {
+		t.Fatalf("expected label NaNError")
+	}
+}
+
+func TestOrdinalEncodeOrderUnknownNaNAndInverse(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList("low", "high", "medium").SetName("satisfaction"),
+		NewDataList(1, 2, 3).SetName("value"),
+	)
+	out, enc, err := dt.OrdinalEncode(OrdinalEncodeOptions{
+		Column:    "satisfaction",
+		Order:     []any{"low", "medium", "high"},
+		NewColumn: "rank",
+	})
+	if err != nil {
+		t.Fatalf("OrdinalEncode failed: %v", err)
+	}
+	assertEncodeCols(t, out, []string{"rank", "value"})
+	assertEncodeData(t, out.GetColByName("rank"), []any{0, 2, 1})
+	if inv, err := enc.Inverse(0, 2, 1); err != nil || !reflect.DeepEqual(inv, []any{"low", "high", "medium"}) {
+		t.Fatalf("ordinal inverse = %#v, %v", inv, err)
+	}
+	roundTrip, err := enc.InverseTransform(out)
+	if err != nil {
+		t.Fatalf("ordinal inverse transform: %v", err)
+	}
+	assertEncodeData(t, roundTrip.GetColByName("satisfaction"), []any{"low", "high", "medium"})
+
+	if _, _, err := dt.OrdinalEncode(OrdinalEncodeOptions{Column: "satisfaction"}); err == nil {
+		t.Fatalf("expected empty Order error")
+	}
+	if _, _, err := dt.OrdinalEncode(OrdinalEncodeOptions{
+		Column:  "satisfaction",
+		Order:   []any{"low", "medium"},
+		Unknown: UnknownError,
+	}); err == nil {
+		t.Fatalf("expected unknown-in-fit error")
+	}
+
+	ignored, _, err := dt.OrdinalEncode(OrdinalEncodeOptions{
+		Column:  "satisfaction",
+		Order:   []any{"low", "medium"},
+		Unknown: UnknownIgnore,
+	})
+	if err != nil {
+		t.Fatalf("ordinal unknown ignore: %v", err)
+	}
+	assertEncodeData(t, ignored.GetColByName("satisfaction"), []any{0, nil, 1})
+
+	_, errEnc, err := NewDataTable(NewDataList("low").SetName("satisfaction")).OrdinalEncode(OrdinalEncodeOptions{
+		Column:  "satisfaction",
+		Order:   []any{"low"},
+		Unknown: UnknownError,
+	})
+	if err != nil {
+		t.Fatalf("fit ordinal strict: %v", err)
+	}
+	if _, err := errEnc.Transform(NewDataTable(NewDataList("high").SetName("satisfaction"))); err == nil {
+		t.Fatalf("expected ordinal transform unknown error")
+	}
+	_, newEnc, err := NewDataTable(NewDataList("low").SetName("satisfaction")).OrdinalEncode(OrdinalEncodeOptions{
+		Column:  "satisfaction",
+		Order:   []any{"low"},
+		Unknown: UnknownAsNew,
+	})
+	if err != nil {
+		t.Fatalf("fit ordinal new: %v", err)
+	}
+	extended, err := newEnc.Transform(NewDataTable(NewDataList("high").SetName("satisfaction")))
+	if err != nil {
+		t.Fatalf("ordinal new transform: %v", err)
+	}
+	assertEncodeData(t, extended.GetColByName("satisfaction"), []any{1})
+
+	missing := NewDataTable(NewDataList("low", nil).SetName("satisfaction"))
+	asCategory, _, err := missing.OrdinalEncode(OrdinalEncodeOptions{
+		Column:    "satisfaction",
+		Order:     []any{"low"},
+		HandleNaN: NaNAsCategory,
+	})
+	if err != nil {
+		t.Fatalf("ordinal NaNAsCategory: %v", err)
+	}
+	assertEncodeData(t, asCategory.GetColByName("satisfaction"), []any{0, 1})
+	skipped, _, err := missing.OrdinalEncode(OrdinalEncodeOptions{
+		Column:    "satisfaction",
+		Order:     []any{"low"},
+		HandleNaN: NaNSkip,
+	})
+	if err != nil {
+		t.Fatalf("ordinal NaNSkip: %v", err)
+	}
+	assertEncodeData(t, skipped.GetColByName("satisfaction"), []any{0, nil})
+	if _, _, err := missing.OrdinalEncode(OrdinalEncodeOptions{
+		Column:    "satisfaction",
+		Order:     []any{"low"},
+		HandleNaN: NaNError,
+	}); err == nil {
+		t.Fatalf("expected ordinal NaNError")
+	}
+}
+
+func TestEncodeErrorsUseColumnResolutionAndDuplicateNames(t *testing.T) {
+	dt := encodeTestTable()
+	if _, _, err := dt.OneHotEncode(OneHotOptions{Columns: []string{"missing"}}); err == nil {
+		t.Fatalf("expected missing column error")
+	}
+	byIndex, _, err := dt.OneHotEncode(OneHotOptions{Columns: []string{"A"}})
+	if err != nil {
+		t.Fatalf("Excel-style column reference failed: %v", err)
+	}
+	assertEncodeData(t, byIndex.GetColByName("color_red"), []any{1, 0, 1})
+
+	_, _, err = dt.LabelEncode(LabelEncodeOptions{Column: "color", NewColumn: "size"})
+	if err == nil || !strings.Contains(err.Error(), "duplicate output column name") {
+		t.Fatalf("expected duplicate-name error, got %v", err)
+	}
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -291,6 +291,12 @@ type IDataTable interface {
 	FillWithMedian(...string) *DataTable
 	FillWithMode(...string) *DataTable
 	FillByInterpolation(...string) *DataTable
+
+	// Encoding
+	OneHotEncode(opts OneHotOptions) (*DataTable, *OneHotEncoder, error)
+	LabelEncode(opts LabelEncodeOptions) (*DataTable, *LabelEncoder, error)
+	OrdinalEncode(opts OrdinalEncodeOptions) (*DataTable, *OrdinalEncoder, error)
+
 	ReplaceInRow(rowIndex int, oldValue, newValue any, mode ...int) *DataTable
 	ReplaceNaNsInRow(rowIndex int, newValue any, mode ...int) *DataTable
 	ReplaceNilsInRow(rowIndex int, newValue any, mode ...int) *DataTable

--- a/skills/insyra/SKILL.md
+++ b/skills/insyra/SKILL.md
@@ -129,6 +129,48 @@ Notes:
 - DataTable `mean`, `median`, and `interpolation` skip non-numeric columns; `mode`, `ffill`, and `bfill` work with any selected column type.
 - `FillByInterpolation` fills gaps inside a sequence; it is distinct from `LinearInterpolation(x)`, which evaluates a y-value at a given x.
 
+### 1c) Encode categorical DataTable columns
+
+Use DataTable categorical encoders before stats methods that require numeric features (`stats.LinearRegression`, KNN, PCA, clustering). These methods return a new table plus a fitted encoder; the receiver is not modified.
+
+```go
+encoded, enc, err := dt.OneHotEncode(insyra.OneHotOptions{
+    Columns:   []string{"plan", "region"},
+    DropFirst: true,
+    Unknown:   insyra.UnknownIgnore,
+})
+if err != nil { log.Fatal(err) }
+
+testEncoded, err := enc.Transform(testDT)       // reuse train mapping
+original, err := enc.InverseTransform(encoded)  // rebuild source columns
+_ = testEncoded
+_ = original
+
+labels, labelEnc, err := dt.LabelEncode(insyra.LabelEncodeOptions{
+    Column:    "segment",
+    NewColumn: "segment_id",
+    SortBy:    insyra.LabelSortByFrequency,
+})
+_ = labels
+classes := labelEnc.Classes()
+values, err := labelEnc.Inverse(0, 2, 1)
+_ = classes
+_ = values
+
+ranked, ordinalEnc, err := dt.OrdinalEncode(insyra.OrdinalEncodeOptions{
+    Column: "satisfaction",
+    Order:  []any{"low", "medium", "high"},
+})
+_ = ranked
+_ = ordinalEnc
+```
+
+Policies:
+- `NaNAsCategory`, `NaNError`, `NaNSkip` handle `nil`/`NaN`.
+- `UnknownIgnore`, `UnknownError`, `UnknownAsNew` handle categories seen only during `Transform`.
+- `LabelSortFirstSeen`, `LabelSortLexicographic`, `LabelSortByFrequency` control label ids.
+- Column refs resolve by name first, then Excel-style index (`A`, `B`, `AA`). Category identity keeps typed values distinct (`1` and `"1"` are different).
+
 ### 2) Read a CSV file into a DataTable + preview
 
 ```go

--- a/skills/use-insyra-cli/SKILL.md
+++ b/skills/use-insyra-cli/SKILL.md
@@ -164,6 +164,11 @@ insyra show report
 # Multi-key + count shorthand
 insyra groupby sales by region,product agg revenue:sum count as report2
 
+# One-shot categorical encoding for DataTable variables
+insyra encode sales onehot region,channel dropfirst true as x
+insyra encode sales label segment newcol segment_id sortby freq keeporiginal true as labeled
+insyra encode survey ordinal satisfaction order low,medium,high unknown error as ranked
+
 # SQL: connect, list tables, load query, transform, write back, disconnect
 # Connections live for the current process only — reopen at the top of every session/script.
 insyra db connect main sqlite:./demo.db
@@ -183,6 +188,12 @@ insyra regression poisson y x1 x2
 ```
 
 `groupby <var> by <col1>[,<col2>...] agg <col>:<op>[:<alias>] [<col>:<op>[:<alias>] ...] [as <var>]` produces a new DataTable with one row per unique key combination. Supported ops: `sum`, `mean` (alias `avg`), `median`, `min`, `max`, `count` (non-nil), `countall` (group size), `std`/`stdev`, `stdp`/`stdevp`, `var`, `varp`, `first`, `last`, `nunique`. The bare token `count` is shorthand for `:countall:count`.
+
+`encode` is one-shot fit+transform only; it does not persist encoder state between CLI commands. For reusable train/test encoders, use the Go API.
+
+- `encode <var> onehot <col1[,col2,...]> [dropfirst true|false] [keeporiginal true|false] [nan category|error|skip] [unknown ignore|error|new] [prefix <p>] [sep <s>] [sortcats true|false] [as <var>]`
+- `encode <var> label <col> [newcol <name>] [sortby firstseen|lex|freq] [nan category|error|skip] [unknown ignore|error|new] [keeporiginal true|false] [as <var>]`
+- `encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]`
 
 ## Database (db) workflow notes
 

--- a/skills/use-insyra-cli/references/cli-command-guide.md
+++ b/skills/use-insyra-cli/references/cli-command-guide.md
@@ -284,6 +284,16 @@ Generated from current command registry (`insyra help`, `insyra help <command>`)
 - Example: `insyra unpivot survey idvars id valuevars Q1,Q2,Q3 varname question valuename score as long`
 - `valuevars` defaults to all non-`idvars` columns. `varname` defaults to `variable`, `valuename` to `value`. `dropna true` skips nil/NaN values.
 
+### `encode`
+- Description: One-shot categorical encoding for DataTable variables (encoder state is not persisted)
+- Usage: `encode <var> onehot|label|ordinal ... [as <var>]`
+- Examples: `insyra encode sales onehot region,channel dropfirst true as x` / `insyra encode sales label segment newcol segment_id sortby freq keeporiginal true as labeled` / `insyra encode survey ordinal satisfaction order low,medium,high unknown error as ranked`
+- Full forms:
+  - `encode <var> onehot <col1[,col2,...]> [dropfirst true|false] [keeporiginal true|false] [nan category|error|skip] [unknown ignore|error|new] [prefix <p>] [sep <s>] [sortcats true|false] [as <var>]`
+  - `encode <var> label <col> [newcol <name>] [sortby firstseen|lex|freq] [nan category|error|skip] [unknown ignore|error|new] [keeporiginal true|false] [as <var>]`
+  - `encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]`
+- Notes: one-shot only; use Go encoders for reusable train/test `Transform`. `order` values are parsed as literals.
+
 ### `ccl`
 - Description: Execute CCL statements on DataTable
 - Usage: `ccl <var> <expression>`

--- a/skills/use-insyra-cli/references/cli-command-usage.md
+++ b/skills/use-insyra-cli/references/cli-command-usage.md
@@ -8,7 +8,7 @@ For expanded subcommand forms and practical examples, see `cli-command-guide.md`
 
 ### Literal value parsing
 
-Commands that take a "value" argument (`addcol`, `set`, `shift ... fill ...`, `replace`, `pivot ... fillna ...`, `load sql ... params ...`, etc.) coerce each token through this ladder (case-insensitive for the keyword rows):
+Commands that take a "value" argument (`addcol`, `set`, `shift ... fill ...`, `replace`, `pivot ... fillna ...`, `encode ordinal ... order ...`, `load sql ... params ...`, etc.) coerce each token through this ladder (case-insensitive for the keyword rows):
 
 | Token                                  | Parsed as           |
 | -------------------------------------- | ------------------- |
@@ -166,6 +166,20 @@ This is separate from boolean-flag parsing used by option arguments like `header
 ## `droprow`
 - Description: Drop rows by index or name
 - Usage: `droprow <var> <index|name...>`
+
+## `encode`
+- Description: One-shot categorical encoding for DataTable variables (encoder state is not persisted)
+- Usage: `encode <var> onehot|label|ordinal ... [as <var>]`
+- Full forms:
+	- `encode <var> onehot <col1[,col2,...]> [dropfirst true|false] [keeporiginal true|false] [nan category|error|skip] [unknown ignore|error|new] [prefix <p>] [sep <s>] [sortcats true|false] [as <var>]`
+	- `encode <var> label <col> [newcol <name>] [sortby firstseen|lex|freq] [nan category|error|skip] [unknown ignore|error|new] [keeporiginal true|false] [as <var>]`
+	- `encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]`
+- Notes:
+  - Works on DataTable variables only.
+  - CLI does one-shot fit+transform; it does not save encoder state for later commands.
+  - `nan`: `category`, `error`, `skip`.
+  - `unknown`: `ignore`, `error`, `new` for onehot/label; `ignore`, `error` for ordinal CLI.
+  - `order` values are comma-separated and parsed through the literal-value ladder.
 
 ## `env`
 - Description: Environment management

--- a/skills/use-insyra-cli/references/cli-commands.md
+++ b/skills/use-insyra-cli/references/cli-commands.md
@@ -78,6 +78,7 @@ This list is generated from `insyra help` in this repository state.
 - `groupby` - Group a DataTable and aggregate columns (split-apply-combine)
 - `pivot` - Reshape long-form DataTable to wide form (long -> wide)
 - `unpivot` - Reshape wide-form DataTable to long form (wide -> long)
+- `encode` - One-shot categorical encoding for DataTable variables
 - `ccl` - Execute CCL statements on DataTable
 - `addcolccl` - Add DataTable column using CCL
 
@@ -157,3 +158,13 @@ This list is generated from `insyra help` in this repository state.
   - `mean`, `median`, and `interpolate` skip non-numeric columns; `mode`, `ffill`, and `bfill` can fill any selected column type.
 - `fillnan <var> mean [as <var>]`
   - Deprecated alias kept for backward compatibility. Only fills NaN (leaves nil alone) and only supports `mean`. Use `fillna <var> mean missing nan` instead.
+
+## Categorical Encoding Command
+
+- `encode <var> onehot <col1[,col2,...]> [dropfirst true|false] [keeporiginal true|false] [nan category|error|skip] [unknown ignore|error|new] [prefix <p>] [sep <s>] [sortcats true|false] [as <var>]`
+  - Emits 0/1 indicator columns for each selected category column.
+- `encode <var> label <col> [newcol <name>] [sortby firstseen|lex|freq] [nan category|error|skip] [unknown ignore|error|new] [keeporiginal true|false] [as <var>]`
+  - Emits integer class ids for one category column.
+- `encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]`
+  - Uses the explicit order as `0..n-1`; `order` values are parsed as literals.
+- CLI encoding is one-shot fit+transform and does not persist encoder state. Use the Go API when you need reusable train/test `Transform`.


### PR DESCRIPTION
Refs #166

## Summary
- Add DataTable one-hot, label, and ordinal encoding APIs with reusable encoder state and inverse transforms.
- Add the one-shot CLI encode command with parser tests.
- Update DataTable docs, CLI docs, and Insyra agent skills/reference files.

## Files touched
- datatable_encode.go, datatable_encode_test.go, interfaces.go
- cli/commands/encode.go, cli/commands/encode_test.go
- Docs/DataTable.md, Docs/cli-dsl.md
- skills/insyra/SKILL.md
- skills/use-insyra-cli/SKILL.md
- skills/use-insyra-cli/references/cli-command-guide.md
- skills/use-insyra-cli/references/cli-command-usage.md
- skills/use-insyra-cli/references/cli-commands.md

## Verification
- go test . ./cli/commands
- go test ./... reaches all normal packages, but the repo currently fails on existing path local/期中期末: malformed import path invalid char '期'
- go build ./... and go vet ./... hit the same existing local/期中期末 path issue
- golangci-lint is not installed in this environment
- go.mod/go.sum unchanged; no isr or CCL helpers added