### PR TITLE
[codex] add describe summaries

### DIFF
--- a/Docs/DataList.md
+++ b/Docs/DataList.md
@@ -1709,6 +1709,29 @@ e.Sum()  // [1, 3, 6, 10]
 e.Std()  // [nil, 0.7071…, 1, 1.2910…]
 ```
 
+### Describe
+
+```go
+type DescribeOptions struct {
+    Percentiles []float64
+    IncludeAll  bool
+}
+
+func (dl *DataList) Describe(options ...DescribeOptions) *DataTable
+```
+
+**Description:** Returns a programmatic summary table. Row names are statistics (`count`, `missing`, `unique`, `top`, `freq`, `mean`, `std`, `min`, percentiles, `max`) and the single output column is named from the DataList name, or `value` when unnamed.
+
+`nil` and `NaN` count as missing. Numeric lists report numeric statistics; non-numeric or mixed lists report categorical statistics (`unique`, `top`, `freq`). `Percentiles` uses values in `[0, 1]`; when omitted it defaults to `0.25`, `0.5`, and `0.75`.
+
+**Example:**
+
+```go
+dl := insyra.NewDataList(1, 2, nil, 4).SetName("score")
+desc := dl.Describe(insyra.DescribeOptions{Percentiles: []float64{0.1, 0.5, 0.9}})
+desc.Show()
+```
+
 ### Summary
 
 ```go

--- a/Docs/DataTable.md
+++ b/Docs/DataTable.md
@@ -739,6 +739,7 @@ func (dt *DataTable) GroupBy(keyCols ...string) *GroupedDataTable
 func (g *GroupedDataTable) Aggregate(configs ...AggregateConfig) *DataTable
 func (g *GroupedDataTable) AggregateAll(op AggregateOp) *DataTable
 func (g *GroupedDataTable) Count() *DataTable
+func (g *GroupedDataTable) Describe(options ...DescribeOptions) *DataTable
 ```
 
 **Description:** Splits the DataTable into groups by one or more key columns and applies aggregate functions to each group ("split-apply-combine"). The result is a new DataTable with one row per unique key combination — key columns first (in `GroupBy` order), then the aggregate columns (in `Aggregate` order). Group order in the output follows the order in which each key combination is first seen during a single linear scan; `nil` keys form their own group, and `int(1)` is kept distinct from the string `"1"`.
@@ -767,6 +768,8 @@ func (g *GroupedDataTable) Count() *DataTable
 | `OpCustom` | User-supplied `Custom func(group *DataList) any` |
 
 **Errors:** Unknown key columns, unknown source columns, missing `Custom` for `OpCustom`, empty configs, and empty key lists are reported via the parent `dt.Err()` instance-level error. The aggregate output is still returned (with affected columns nil-filled or empty), so callers can inspect partial results and continue chaining.
+
+**Describe:** `GroupBy(...).Describe()` returns one row per group. Key columns are emitted first, followed by flattened summary columns such as `revenue_count`, `revenue_mean`, `revenue_25%`, and `segment_unique` when `IncludeAll` is enabled. Group order follows the same first-seen order as `Aggregate`.
 
 **Example (single key, multiple aggregates):**
 
@@ -3634,6 +3637,32 @@ filtered := dt.FilterRowsByRowIndexEqualTo(3) // Only row 3
 ```
 
 ## Statistical Analysis
+
+### Describe
+
+```go
+type DescribeOptions struct {
+    Percentiles []float64
+    IncludeAll  bool
+}
+
+func (dt *DataTable) Describe(options ...DescribeOptions) *DataTable
+```
+
+**Description:** Returns a programmatic per-column summary table. Row names are statistics (`count`, `missing`, `unique`, `top`, `freq`, `mean`, `std`, `min`, percentiles, `max`) and columns are source columns.
+
+By default, only columns whose non-missing values are all numeric are included. With `IncludeAll: true`, non-numeric and mixed columns are included with categorical statistics. `nil` and `NaN` count as missing. `Percentiles` uses values in `[0, 1]`; when omitted it defaults to `0.25`, `0.5`, and `0.75`.
+
+**Example:**
+
+```go
+desc := dt.Describe(insyra.DescribeOptions{
+    IncludeAll:  true,
+    Percentiles: []float64{0.1, 0.5, 0.9},
+})
+
+byRegion := dt.GroupBy("region").Describe(insyra.DescribeOptions{IncludeAll: true})
+```
 
 ### Summary
 

--- a/Docs/cli-dsl.md
+++ b/Docs/cli-dsl.md
@@ -524,6 +524,7 @@ Source policy:
 | `cummin` | `cummin <var> [as <var>]` | Running minimum (historical low) |
 | `cumprod` | `cumprod <var> [as <var>]` | Running product |
 | `cumsum` | `cumsum <var> [as <var>]` | Running total |
+| `describe` | `describe <var> [by <col1[,col2,...]>] [all true\|false] [percentiles <p1,p2,...>] [as <var>]` | Create a programmatic summary table |
 | `diff` | `diff <var> [as <var>]` | Difference (legacy, length n-1) |
 | `diffn` | `diffn <var> <periods> [as <var>]` | Backward difference, same-length output with leading nils |
 | `drop` | `drop <var>` | Delete variable |
@@ -610,6 +611,20 @@ Source policy:
 | `vars` | `vars` | List variables in current environment |
 | `version` | `version` | Show insyra version |
 | `ztest` | `ztest single\|two ...` | Z-test commands |
+
+## Describe Command
+
+`describe` creates a DataTable summary that can be saved or reused in later commands.
+
+```bash
+describe sales as summary
+describe sales all true as summary_all
+describe sales percentiles 0.1,0.5,0.9 as summary_p
+describe sales by region all true as region_summary
+save region_summary region_summary.csv
+```
+
+Without `as`, the result is stored in `$result`. `all true` includes non-numeric and mixed columns. `by` is available for DataTable variables only.
 
 ## Regression Forms
 

--- a/cli/commands/describe.go
+++ b/cli/commands/describe.go
@@ -1,0 +1,146 @@
+package commands
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	insyra "github.com/HazelnutParadise/insyra"
+)
+
+func init() {
+	_ = Register(&CommandHandler{
+		Name:        "describe",
+		Usage:       "describe <var> [by <col1>[,<col2>...]] [all true|false] [percentiles <p1,p2,...>] [as <var>]",
+		Description: "Create a programmatic summary table",
+		Forms: []string{
+			"describe <var> [as <var>]",
+			"describe <var> all true|false [as <var>]",
+			"describe <var> percentiles <p1,p2,...> [as <var>]",
+			"describe <var> by <col1>[,<col2>...] [all true|false] [percentiles <p1,p2,...>] [as <var>]",
+		},
+		Examples: []string{
+			"insyra describe sales as summary",
+			"insyra describe sales all true as summary",
+			"insyra describe sales percentiles 0.1,0.5,0.9 as summary",
+			"insyra describe sales by region all true as by_region",
+		},
+		Run: runDescribeCommand,
+	})
+}
+
+type describeCommandOptions struct {
+	insyra.DescribeOptions
+	GroupBy []string
+}
+
+func runDescribeCommand(ctx *ExecContext, args []string) error {
+	coreArgs, alias := parseAlias(args)
+	if len(coreArgs) < 1 {
+		return fmt.Errorf("usage: describe <var> [by <cols>] [all true|false] [percentiles <p1,p2,...>] [as <var>]")
+	}
+	varName := coreArgs[0]
+	opts, err := parseDescribeCommandOptions(coreArgs[1:])
+	if err != nil {
+		return err
+	}
+	value, exists := ctx.Vars[varName]
+	if !exists {
+		return fmt.Errorf("variable not found: %s", varName)
+	}
+
+	var result *insyra.DataTable
+	switch typed := value.(type) {
+	case *insyra.DataTable:
+		if len(opts.GroupBy) > 0 {
+			result = typed.GroupBy(opts.GroupBy...).Describe(opts.DescribeOptions)
+			if errInfo := typed.Err(); errInfo != nil {
+				_, _ = fmt.Fprintf(ctx.Output, "warning: %s\n", errInfo.Error())
+			}
+		} else {
+			result = typed.Describe(opts.DescribeOptions)
+		}
+	case *insyra.DataList:
+		if len(opts.GroupBy) > 0 {
+			return fmt.Errorf("describe: by is only supported for DataTable variables")
+		}
+		result = typed.Describe(opts.DescribeOptions)
+	default:
+		return fmt.Errorf("describe is only supported for DataTable/DataList")
+	}
+	ctx.Vars[alias] = result
+	result.Show()
+	_, _ = fmt.Fprintf(ctx.Output, "saved description as %s\n", alias)
+	return nil
+}
+
+func parseDescribeCommandOptions(args []string) (describeCommandOptions, error) {
+	var opts describeCommandOptions
+	for i := 0; i < len(args); {
+		key := strings.ToLower(args[i])
+		if i+1 >= len(args) {
+			return opts, fmt.Errorf("describe: option %q requires a value", args[i])
+		}
+		value := args[i+1]
+		switch key {
+		case "by":
+			cols := parseDescribeColumns(value)
+			if len(cols) == 0 {
+				return opts, fmt.Errorf("describe: by requires at least one column")
+			}
+			opts.GroupBy = cols
+		case "all":
+			parsed, err := parseFlexBool(value)
+			if err != nil {
+				return opts, fmt.Errorf("describe: invalid value for all: %w", err)
+			}
+			opts.IncludeAll = parsed
+		case "percentiles":
+			ps, err := parseDescribePercentiles(value)
+			if err != nil {
+				return opts, err
+			}
+			opts.Percentiles = ps
+		default:
+			return opts, fmt.Errorf("describe: unknown option %q (supported: by, all, percentiles)", args[i])
+		}
+		i += 2
+	}
+	return opts, nil
+}
+
+func parseDescribeColumns(raw string) []string {
+	tokens := strings.Split(raw, ",")
+	cols := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token != "" {
+			cols = append(cols, token)
+		}
+	}
+	return cols
+}
+
+func parseDescribePercentiles(raw string) ([]float64, error) {
+	tokens := strings.Split(raw, ",")
+	ps := make([]float64, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		p, err := strconv.ParseFloat(token, 64)
+		if err != nil {
+			return nil, fmt.Errorf("describe: invalid percentile %q", token)
+		}
+		if math.IsNaN(p) || math.IsInf(p, 0) || p < 0 || p > 1 {
+			return nil, fmt.Errorf("describe: percentile %v out of range [0, 1]", p)
+		}
+		ps = append(ps, p)
+	}
+	if len(ps) == 0 {
+		return nil, fmt.Errorf("describe: percentiles requires at least one value")
+	}
+	return ps, nil
+}

--- a/cli/commands/describe_test.go
+++ b/cli/commands/describe_test.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	insyra "github.com/HazelnutParadise/insyra"
+)
+
+func describeTestTable() *insyra.DataTable {
+	return insyra.NewDataTable(
+		insyra.NewDataList("east", "east", "west").SetName("region"),
+		insyra.NewDataList(10, 20, 30).SetName("revenue"),
+		insyra.NewDataList("retail", "online", "retail").SetName("segment"),
+	)
+}
+
+func TestRunDescribeCommand_DataTableAsAlias(t *testing.T) {
+	ctx := &ExecContext{Vars: map[string]any{"sales": describeTestTable()}, Output: &bytes.Buffer{}}
+
+	if err := runDescribeCommand(ctx, []string{"sales", "as", "summary"}); err != nil {
+		t.Fatalf("runDescribeCommand failed: %v", err)
+	}
+
+	out, ok := ctx.Vars["summary"].(*insyra.DataTable)
+	if !ok {
+		t.Fatalf("expected summary DataTable, got %T", ctx.Vars["summary"])
+	}
+	if got := out.ColNames(); len(got) != 1 || got[0] != "revenue" {
+		t.Fatalf("expected only revenue by default, got %v", got)
+	}
+}
+
+func TestRunDescribeCommand_DefaultResultAndPercentiles(t *testing.T) {
+	ctx := &ExecContext{Vars: map[string]any{"x": insyra.NewDataList(1, 2, 3, 4, 5)}, Output: &bytes.Buffer{}}
+
+	if err := runDescribeCommand(ctx, []string{"x", "percentiles", "0.1,0.9"}); err != nil {
+		t.Fatalf("runDescribeCommand failed: %v", err)
+	}
+
+	out, ok := ctx.Vars["$result"].(*insyra.DataTable)
+	if !ok {
+		t.Fatalf("expected $result DataTable, got %T", ctx.Vars["$result"])
+	}
+	if _, ok := out.GetRowIndexByName("10%"); !ok {
+		t.Fatal("expected 10% row")
+	}
+	if !strings.Contains(ctx.Output.(*bytes.Buffer).String(), "saved description as $result") {
+		t.Fatal("expected save message for $result")
+	}
+}
+
+func TestRunDescribeCommand_GroupByIncludeAll(t *testing.T) {
+	ctx := &ExecContext{Vars: map[string]any{"sales": describeTestTable()}, Output: &bytes.Buffer{}}
+
+	if err := runDescribeCommand(ctx, []string{"sales", "by", "region", "all", "true", "as", "summary"}); err != nil {
+		t.Fatalf("runDescribeCommand failed: %v", err)
+	}
+
+	out := ctx.Vars["summary"].(*insyra.DataTable)
+	if got := out.GetColByName("segment_unique").Data(); got[0] != 2 || got[1] != 1 {
+		t.Fatalf("unexpected segment_unique: %v", got)
+	}
+}
+
+func TestRunDescribeCommand_Errors(t *testing.T) {
+	ctx := &ExecContext{Vars: map[string]any{"x": insyra.NewDataList(1, 2, 3)}, Output: &bytes.Buffer{}}
+	if err := runDescribeCommand(ctx, []string{"missing"}); err == nil {
+		t.Fatal("expected unknown variable error")
+	}
+	if err := runDescribeCommand(ctx, []string{"x", "by", "region"}); err == nil {
+		t.Fatal("expected DataList by error")
+	}
+	if err := runDescribeCommand(ctx, []string{"x", "percentiles", "1.5"}); err == nil {
+		t.Fatal("expected invalid percentile error")
+	}
+	if err := runDescribeCommand(ctx, []string{"x", "all"}); err == nil {
+		t.Fatal("expected missing option value error")
+	}
+}

--- a/datalist_describe.go
+++ b/datalist_describe.go
@@ -1,0 +1,27 @@
+package insyra
+
+// Describe returns a programmatic statistical summary of the DataList.
+func (dl *DataList) Describe(options ...DescribeOptions) *DataTable {
+	out := NewDataTable()
+	cfg, err := normalizeDescribeOptions(options)
+	if err != nil {
+		dl.warn("Describe", "%s", err)
+		return out
+	}
+
+	var name string
+	var data []any
+	dl.AtomicDo(func(dl *DataList) {
+		name = dl.name
+		data = append([]any(nil), dl.data...)
+	})
+	if name == "" {
+		name = "value"
+	}
+
+	summary := describeValues(data, cfg.percentiles)
+	statNames := describeStatNames(cfg.percentiles)
+	out.AppendCols(describeSummaryColumn(name, summary, statNames))
+	out.SetRowNames(statNames)
+	return out
+}

--- a/datalist_describe_test.go
+++ b/datalist_describe_test.go
@@ -1,0 +1,48 @@
+package insyra
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDataListDescribeNumeric(t *testing.T) {
+	dl := NewDataList(1, 2, 3, 4).SetName("x")
+
+	desc := dl.Describe()
+
+	if got := desc.GetColByName("x").Data(); len(got) != 12 {
+		t.Fatalf("expected 12 summary rows, got %d: %v", len(got), got)
+	}
+	assertDescribeValue(t, desc, "count", "x", 4)
+	assertDescribeValue(t, desc, "missing", "x", 0)
+	assertDescribeValue(t, desc, "mean", "x", 2.5)
+	assertDescribeValue(t, desc, "25%", "x", 1.75)
+	assertDescribeValue(t, desc, "50%", "x", 2.5)
+	assertDescribeValue(t, desc, "75%", "x", 3.25)
+}
+
+func TestDataListDescribeMissingAndString(t *testing.T) {
+	dl := NewDataList("a", "b", "a", nil, math.NaN())
+
+	desc := dl.Describe()
+
+	assertDescribeValue(t, desc, "count", "value", 3)
+	assertDescribeValue(t, desc, "missing", "value", 2)
+	assertDescribeValue(t, desc, "unique", "value", 2)
+	assertDescribeValue(t, desc, "top", "value", "a")
+	assertDescribeValue(t, desc, "freq", "value", 2)
+	assertDescribeNil(t, desc, "mean", "value")
+}
+
+func TestDataListDescribeInvalidPercentileSetsErr(t *testing.T) {
+	dl := NewDataList(1, 2, 3)
+
+	desc := dl.Describe(DescribeOptions{Percentiles: []float64{1.2}})
+
+	if desc.NumCols() != 0 {
+		t.Fatalf("expected empty description for invalid percentile, got %d columns", desc.NumCols())
+	}
+	if dl.Err() == nil {
+		t.Fatal("expected invalid percentile to be recorded on DataList Err")
+	}
+}

--- a/datatable_describe.go
+++ b/datatable_describe.go
@@ -1,0 +1,38 @@
+package insyra
+
+// Describe returns a programmatic per-column statistical summary of the
+// DataTable. By default it includes only numeric columns; IncludeAll also
+// includes non-numeric and mixed columns.
+func (dt *DataTable) Describe(options ...DescribeOptions) *DataTable {
+	out := NewDataTable()
+	cfg, err := normalizeDescribeOptions(options)
+	if err != nil {
+		dt.warn("Describe", "%s", err)
+		return out
+	}
+
+	var columns []*DataList
+	dt.AtomicDo(func(dt *DataTable) {
+		columns = make([]*DataList, len(dt.columns))
+		for i, col := range dt.columns {
+			snapshot := NewDataList(col.data...)
+			snapshot.name = col.name
+			columns[i] = snapshot
+		}
+	})
+
+	statNames := describeStatNames(cfg.percentiles)
+	outCols := make([]*DataList, 0, len(columns))
+	for i, col := range columns {
+		summary := describeValues(col.data, cfg.percentiles)
+		if summary.kind != describeKindNumeric && !cfg.includeAll {
+			continue
+		}
+		outCols = append(outCols, describeSummaryColumn(describeColumnLabel(i, col.name), summary, statNames))
+	}
+	if len(outCols) > 0 {
+		out.AppendCols(outCols...)
+		out.SetRowNames(statNames)
+	}
+	return out
+}

--- a/datatable_describe_test.go
+++ b/datatable_describe_test.go
@@ -1,0 +1,106 @@
+package insyra
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDataTableDescribeSkipsNonNumericByDefault(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(1, 2, 3).SetName("x"),
+		NewDataList("a", "b", "a").SetName("label"),
+		NewDataList(10, nil, math.NaN()).SetName("y"),
+	)
+
+	desc := dt.Describe()
+
+	if got := desc.ColNames(); len(got) != 2 || got[0] != "x" || got[1] != "y" {
+		t.Fatalf("expected only numeric columns x,y, got %v", got)
+	}
+	assertDescribeValue(t, desc, "mean", "x", 2.0)
+	assertDescribeValue(t, desc, "count", "y", 1)
+	assertDescribeValue(t, desc, "missing", "y", 2)
+}
+
+func TestDataTableDescribeIncludeAll(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList(1, 2, 3).SetName("x"),
+		NewDataList("a", "b", "a", nil).SetName("label"),
+		NewDataList(1, "1", true).SetName("mixed"),
+	)
+
+	desc := dt.Describe(DescribeOptions{IncludeAll: true})
+
+	if got := desc.ColNames(); len(got) != 3 {
+		t.Fatalf("expected all columns, got %v", got)
+	}
+	assertDescribeValue(t, desc, "unique", "label", 2)
+	assertDescribeValue(t, desc, "top", "label", "a")
+	assertDescribeValue(t, desc, "freq", "label", 2)
+	assertDescribeValue(t, desc, "unique", "mixed", 3)
+	assertDescribeNil(t, desc, "mean", "mixed")
+}
+
+func TestDataTableDescribeCustomPercentiles(t *testing.T) {
+	dt := NewDataTable(NewDataList(1, 2, 3, 4, 5).SetName("x"))
+
+	desc := dt.Describe(DescribeOptions{Percentiles: []float64{0.9, 0.1, 0.1}})
+
+	if _, ok := desc.GetRowIndexByName("10%"); !ok {
+		t.Fatal("expected 10% row")
+	}
+	if _, ok := desc.GetRowIndexByName("90%"); !ok {
+		t.Fatal("expected 90% row")
+	}
+	assertDescribeValue(t, desc, "10%", "x", 1.4)
+	assertDescribeValue(t, desc, "90%", "x", 4.6)
+}
+
+func TestDataTableDescribeAllMissingColumn(t *testing.T) {
+	dt := NewDataTable(NewDataList(nil, math.NaN()).SetName("x"))
+
+	desc := dt.Describe()
+	if desc.NumCols() != 0 {
+		t.Fatalf("expected all-missing column to be skipped by default, got %v", desc.ColNames())
+	}
+
+	all := dt.Describe(DescribeOptions{IncludeAll: true})
+	assertDescribeValue(t, all, "count", "x", 0)
+	assertDescribeValue(t, all, "missing", "x", 2)
+	assertDescribeValue(t, all, "unique", "x", 0)
+}
+
+func assertDescribeValue(t *testing.T, dt *DataTable, rowName, colName string, want any) {
+	t.Helper()
+	row, ok := dt.GetRowIndexByName(rowName)
+	if !ok {
+		t.Fatalf("row %q not found", rowName)
+	}
+	got := dt.GetColByName(colName).Get(row)
+	switch w := want.(type) {
+	case float64:
+		g, ok := got.(float64)
+		if !ok || math.Abs(g-w) > 1e-9 {
+			t.Fatalf("row %s col %s: got %v (%T), want %v", rowName, colName, got, got, want)
+		}
+	case int:
+		if got != w {
+			t.Fatalf("row %s col %s: got %v (%T), want %v", rowName, colName, got, got, want)
+		}
+	default:
+		if got != want {
+			t.Fatalf("row %s col %s: got %v (%T), want %v", rowName, colName, got, got, want)
+		}
+	}
+}
+
+func assertDescribeNil(t *testing.T, dt *DataTable, rowName, colName string) {
+	t.Helper()
+	row, ok := dt.GetRowIndexByName(rowName)
+	if !ok {
+		t.Fatalf("row %q not found", rowName)
+	}
+	if got := dt.GetColByName(colName).Get(row); got != nil {
+		t.Fatalf("row %s col %s: got %v, want nil", rowName, colName, got)
+	}
+}

--- a/datatable_groupby_describe.go
+++ b/datatable_groupby_describe.go
@@ -1,0 +1,95 @@
+package insyra
+
+// Describe returns one summary row per group. Key columns are emitted first,
+// followed by flattened summary columns named "<source>_<stat>".
+func (g *GroupedDataTable) Describe(options ...DescribeOptions) *DataTable {
+	out := NewDataTable()
+	if g == nil {
+		return out
+	}
+	cfg, err := normalizeDescribeOptions(options)
+	if err != nil {
+		if g.parent != nil {
+			g.parent.warn("Describe", "%s", err)
+		}
+		return out
+	}
+	if g.initErr != "" {
+		if g.parent != nil {
+			g.parent.warn("Describe", "%s", g.initErr)
+		}
+		return out
+	}
+
+	keySet := map[int]struct{}{}
+	for _, n := range g.keyColNumbers {
+		keySet[n] = struct{}{}
+	}
+
+	type describeSource struct {
+		index   int
+		label   string
+		stats   []string
+		summary describeColumnSummary
+	}
+	sources := make([]describeSource, 0, len(g.columnsSnapshot))
+	for i, col := range g.columnsSnapshot {
+		if _, isKey := keySet[i]; isKey {
+			continue
+		}
+		summary := describeValues(col.data, cfg.percentiles)
+		if summary.kind != describeKindNumeric && !cfg.includeAll {
+			continue
+		}
+		stats := describeNumericStatNames(cfg.percentiles)
+		if summary.kind != describeKindNumeric {
+			stats = describeCategoryStatNames()
+		}
+		sources = append(sources, describeSource{
+			index:   i,
+			label:   describeColumnLabel(i, col.name),
+			stats:   stats,
+			summary: summary,
+		})
+	}
+
+	resultCols := make([]*DataList, 0, len(g.keyColLabels)+len(sources)*len(describeStatNames(cfg.percentiles)))
+	for _, label := range g.keyColLabels {
+		resultCols = append(resultCols, NewDataList().SetName(label))
+	}
+	for _, src := range sources {
+		for _, stat := range src.stats {
+			resultCols = append(resultCols, NewDataList().SetName(src.label+"_"+stat))
+		}
+	}
+
+	for _, encoded := range g.groupOrder {
+		keyVals := g.groupKeyValues[encoded]
+		for i, v := range keyVals {
+			resultCols[i].Append(v)
+		}
+		offset := len(g.keyColLabels)
+		rowIdxs := g.rowsByGroup[encoded]
+		for _, src := range sources {
+			values := make([]any, 0, len(rowIdxs))
+			col := g.columnsSnapshot[src.index]
+			for _, row := range rowIdxs {
+				if row < len(col.data) {
+					values = append(values, col.data[row])
+				} else {
+					values = append(values, nil)
+				}
+			}
+			summary := describeValues(values, cfg.percentiles)
+			for _, stat := range src.stats {
+				resultCols[offset].Append(summary.values[stat])
+				offset++
+			}
+		}
+	}
+
+	if len(resultCols) > 0 {
+		out.AppendCols(resultCols...)
+	}
+	return out
+}

--- a/datatable_groupby_describe_test.go
+++ b/datatable_groupby_describe_test.go
@@ -1,0 +1,39 @@
+package insyra
+
+import "testing"
+
+func TestGroupedDataTableDescribeNumeric(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList("APAC", "APAC", "EMEA").SetName("region"),
+		NewDataList(10, 20, 30).SetName("revenue"),
+		NewDataList("retail", "retail", "enterprise").SetName("segment"),
+	)
+
+	desc := dt.GroupBy("region").Describe()
+
+	if got := desc.ColNames(); len(got) != 10 || got[0] != "region" || got[1] != "revenue_count" {
+		t.Fatalf("unexpected grouped describe columns: %v", got)
+	}
+	if got := desc.GetColByName("region").Data(); got[0] != "APAC" || got[1] != "EMEA" {
+		t.Fatalf("unexpected group order: %v", got)
+	}
+	if got := desc.GetColByName("revenue_mean").Data(); got[0] != 15.0 || got[1] != 30.0 {
+		t.Fatalf("unexpected revenue_mean: %v", got)
+	}
+}
+
+func TestGroupedDataTableDescribeIncludeAll(t *testing.T) {
+	dt := NewDataTable(
+		NewDataList("APAC", "APAC", "EMEA").SetName("region"),
+		NewDataList("retail", "online", "retail").SetName("segment"),
+	)
+
+	desc := dt.GroupBy("region").Describe(DescribeOptions{IncludeAll: true})
+
+	if got := desc.GetColByName("segment_unique").Data(); got[0] != 2 || got[1] != 1 {
+		t.Fatalf("unexpected segment_unique: %v", got)
+	}
+	if got := desc.GetColByName("segment_top").Data(); got[0] != "retail" || got[1] != "retail" {
+		t.Fatalf("unexpected segment_top: %v", got)
+	}
+}

--- a/describe_options.go
+++ b/describe_options.go
@@ -1,0 +1,87 @@
+package insyra
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// DescribeOptions configures Describe output for DataList, DataTable, and
+// GroupedDataTable.
+type DescribeOptions struct {
+	// Percentiles contains percentile positions in the inclusive range [0, 1].
+	// When omitted, Describe uses 0.25, 0.5, and 0.75.
+	Percentiles []float64
+	// IncludeAll includes non-numeric and mixed columns in DataTable and
+	// GroupedDataTable descriptions.
+	IncludeAll bool
+}
+
+type describeConfig struct {
+	percentiles []float64
+	includeAll  bool
+}
+
+var defaultDescribePercentiles = []float64{0.25, 0.5, 0.75}
+
+func normalizeDescribeOptions(options []DescribeOptions) (describeConfig, error) {
+	cfg := describeConfig{
+		percentiles: append([]float64(nil), defaultDescribePercentiles...),
+	}
+	if len(options) > 0 {
+		opt := options[0]
+		cfg.includeAll = opt.IncludeAll
+		if opt.Percentiles != nil {
+			cfg.percentiles = append([]float64(nil), opt.Percentiles...)
+		}
+	}
+
+	for _, p := range cfg.percentiles {
+		if math.IsNaN(p) || math.IsInf(p, 0) || p < 0 || p > 1 {
+			return describeConfig{}, fmt.Errorf("percentile %v out of range [0, 1]", p)
+		}
+	}
+	sort.Float64s(cfg.percentiles)
+	unique := cfg.percentiles[:0]
+	for _, p := range cfg.percentiles {
+		if len(unique) == 0 || p != unique[len(unique)-1] {
+			unique = append(unique, p)
+		}
+	}
+	cfg.percentiles = unique
+	return cfg, nil
+}
+
+func describeStatNames(percentiles []float64) []string {
+	names := []string{"count", "missing", "unique", "top", "freq", "mean", "std", "min"}
+	for _, p := range percentiles {
+		names = append(names, describePercentileName(p))
+	}
+	names = append(names, "max")
+	return names
+}
+
+func describeNumericStatNames(percentiles []float64) []string {
+	names := []string{"count", "missing", "mean", "std", "min"}
+	for _, p := range percentiles {
+		names = append(names, describePercentileName(p))
+	}
+	names = append(names, "max")
+	return names
+}
+
+func describeCategoryStatNames() []string {
+	return []string{"count", "missing", "unique", "top", "freq"}
+}
+
+func describePercentileName(p float64) string {
+	percent := p * 100
+	if math.Abs(percent-math.Round(percent)) < 1e-9 {
+		return fmt.Sprintf("%.0f%%", math.Round(percent))
+	}
+	s := strconv.FormatFloat(percent, 'f', -1, 64)
+	s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	return s + "%"
+}

--- a/describe_stats.go
+++ b/describe_stats.go
@@ -1,0 +1,184 @@
+package insyra
+
+import (
+	"math"
+	"sort"
+)
+
+type describeKind int
+
+const (
+	describeKindNumeric describeKind = iota
+	describeKindCategory
+	describeKindEmpty
+)
+
+type describeColumnSummary struct {
+	kind    describeKind
+	values  map[string]any
+	hasData bool
+}
+
+func describeValues(values []any, percentiles []float64) describeColumnSummary {
+	numeric, missing, allNumeric := collectDescribeNumeric(values)
+	if allNumeric && len(numeric) > 0 {
+		return describeNumericValues(numeric, missing, percentiles)
+	}
+	if len(values) == 0 {
+		return describeColumnSummary{
+			kind: describeKindEmpty,
+			values: map[string]any{
+				"count":   0,
+				"missing": 0,
+			},
+		}
+	}
+	return describeCategoryValues(values, missing)
+}
+
+func collectDescribeNumeric(values []any) ([]float64, int, bool) {
+	numeric := make([]float64, 0, len(values))
+	missing := 0
+	allNumeric := true
+	for _, v := range values {
+		if describeIsMissing(v) {
+			missing++
+			continue
+		}
+		f, ok := ToFloat64Safe(v)
+		if !ok || math.IsNaN(f) {
+			allNumeric = false
+			continue
+		}
+		numeric = append(numeric, f)
+	}
+	return numeric, missing, allNumeric
+}
+
+func describeIsMissing(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch tv := v.(type) {
+	case float64:
+		return math.IsNaN(tv)
+	case float32:
+		return math.IsNaN(float64(tv))
+	default:
+		return false
+	}
+}
+
+func describeNumericValues(values []float64, missing int, percentiles []float64) describeColumnSummary {
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+
+	sum := 0.0
+	for _, v := range sorted {
+		sum += v
+	}
+	mean := sum / float64(len(sorted))
+
+	var std any
+	if len(sorted) >= 2 {
+		ss := 0.0
+		for _, v := range sorted {
+			diff := v - mean
+			ss += diff * diff
+		}
+		std = math.Sqrt(ss / float64(len(sorted)-1))
+	}
+
+	stats := map[string]any{
+		"count":   len(sorted),
+		"missing": missing,
+		"mean":    mean,
+		"std":     std,
+		"min":     sorted[0],
+		"max":     sorted[len(sorted)-1],
+	}
+	for _, p := range percentiles {
+		stats[describePercentileName(p)] = describePercentile(sorted, p)
+	}
+	return describeColumnSummary{kind: describeKindNumeric, values: stats, hasData: true}
+}
+
+func describePercentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return math.NaN()
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	h := p * float64(n-1)
+	lower := int(math.Floor(h))
+	upper := int(math.Ceil(h))
+	if lower == upper {
+		return sorted[lower]
+	}
+	fraction := h - float64(lower)
+	return sorted[lower] + fraction*(sorted[upper]-sorted[lower])
+}
+
+func describeCategoryValues(values []any, missing int) describeColumnSummary {
+	seen := map[string]struct{}{}
+	counts := map[string]int{}
+	firstValue := map[string]any{}
+	orderedKeys := make([]string, 0)
+	count := 0
+	for _, v := range values {
+		if describeIsMissing(v) {
+			continue
+		}
+		key := uniqueKey(v)
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			firstValue[key] = v
+			orderedKeys = append(orderedKeys, key)
+		}
+		counts[key]++
+		count++
+	}
+
+	var top any
+	var freq any
+	best := 0
+	for _, key := range orderedKeys {
+		if counts[key] > best {
+			best = counts[key]
+			top = firstValue[key]
+			freq = best
+		}
+	}
+
+	return describeColumnSummary{
+		kind: describeKindCategory,
+		values: map[string]any{
+			"count":   count,
+			"missing": missing,
+			"unique":  len(seen),
+			"top":     top,
+			"freq":    freq,
+		},
+		hasData: count > 0,
+	}
+}
+
+func describeSummaryColumn(name string, summary describeColumnSummary, statNames []string) *DataList {
+	data := make([]any, len(statNames))
+	for i, stat := range statNames {
+		data[i] = summary.values[stat]
+	}
+	return NewDataList(data...).SetName(name)
+}
+
+func describeColumnLabel(index int, name string) string {
+	if name != "" {
+		return name
+	}
+	if label, ok := CalcColIndex(index); ok {
+		return label
+	}
+	return ""
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -85,6 +85,7 @@ type IDataList interface {
 	IQR() float64
 	Percentile(float64) float64
 	Difference() *DataList
+	Describe(...DescribeOptions) *DataTable
 	Summary()
 
 	// Error handling (instance-level)
@@ -214,6 +215,7 @@ type IDataTable interface {
 	NumCols() int
 	Count(value any) int
 	Mean() any
+	Describe(...DescribeOptions) *DataTable
 	Summary()
 
 	// Error handling (instance-level)

--- a/skills/insyra/SKILL.md
+++ b/skills/insyra/SKILL.md
@@ -317,6 +317,20 @@ weighted := dt.GroupBy("region").Aggregate(
 
 Supported `AggregateOp`: `OpSum`, `OpMean`, `OpMedian`, `OpMin`, `OpMax`, `OpCount` (non-nil), `OpCountAll` (group size), `OpStdev`, `OpStdevP`, `OpVar`, `OpVarP`, `OpFirst`, `OpLast`, `OpNUnique`, `OpCustom`. Group order in the result follows the order each key combination is first seen during a single linear scan; `nil` keys form their own group, and `int(1)` and string `"1"` are kept distinct.
 
+### 3c.1) Describe summaries
+
+Use `Describe` when you need a reusable summary table instead of console-only `Summary`.
+
+```go
+desc := dt.Describe(insyra.DescribeOptions{
+    IncludeAll:  true,
+    Percentiles: []float64{0.1, 0.5, 0.9},
+})
+byRegion := dt.GroupBy("region").Describe(insyra.DescribeOptions{IncludeAll: true})
+```
+
+`DataList.Describe()` and `DataTable.Describe()` return `*DataTable`. `GroupBy(...).Describe()` returns one row per group with flattened columns such as `revenue_mean` and `segment_top`. `nil` and `NaN` are missing. Do not assume an `isr` wrapper exists; call the root API.
+
 ### 3d) Pivot / Unpivot (long ↔ wide reshape)
 
 Use `Pivot` to spread the unique values of one column into new column headers (long → wide), and `Unpivot` to do the inverse (wide → long). Both return `(*DataTable, error)`; on failure the returned table is empty and carries the error on its `Err()`, so chained calls remain safe.

--- a/skills/use-insyra-cli/SKILL.md
+++ b/skills/use-insyra-cli/SKILL.md
@@ -164,6 +164,11 @@ insyra show report
 # Multi-key + count shorthand
 insyra groupby sales by region,product agg revenue:sum count as report2
 
+# Programmatic summaries that can be saved
+insyra describe sales all true as summary
+insyra describe sales by region percentiles 0.1,0.5,0.9 as region_summary
+insyra save region_summary region_summary.csv
+
 # One-shot categorical encoding for DataTable variables
 insyra encode sales onehot region,channel dropfirst true as x
 insyra encode sales label segment newcol segment_id sortby freq keeporiginal true as labeled
@@ -188,6 +193,8 @@ insyra regression poisson y x1 x2
 ```
 
 `groupby <var> by <col1>[,<col2>...] agg <col>:<op>[:<alias>] [<col>:<op>[:<alias>] ...] [as <var>]` produces a new DataTable with one row per unique key combination. Supported ops: `sum`, `mean` (alias `avg`), `median`, `min`, `max`, `count` (non-nil), `countall` (group size), `std`/`stdev`, `stdp`/`stdevp`, `var`, `varp`, `first`, `last`, `nunique`. The bare token `count` is shorthand for `:countall:count`.
+
+`describe <var> [by <col1>[,<col2>...]] [all true|false] [percentiles <p1,p2,...>] [as <var>]` creates a reusable summary DataTable. Without `as`, it saves to `$result`. `all true` includes non-numeric and mixed columns; `by` is DataTable-only and returns one row per group.
 
 `encode` is one-shot fit+transform only; it does not persist encoder state between CLI commands. For reusable train/test encoders, use the Go API.
 

--- a/skills/use-insyra-cli/references/cli-command-guide.md
+++ b/skills/use-insyra-cli/references/cli-command-guide.md
@@ -85,6 +85,12 @@ Generated from current command registry (`insyra help`, `insyra help <command>`)
 - Usage: `summary <var>`
 - Example: `insyra summary x`
 
+### `describe`
+- Description: Create a reusable summary DataTable
+- Usage: `describe <var> [by <col1[,col2,...]>] [all true|false] [percentiles <p1,p2,...>] [as <var>]`
+- Example: `insyra describe sales all true as summary`
+- Grouped example: `insyra describe sales by region percentiles 0.1,0.5,0.9 as region_summary`
+
 ## Data Creation / IO
 ### `newdl`
 - Description: Create DataList manually

--- a/skills/use-insyra-cli/references/cli-command-usage.md
+++ b/skills/use-insyra-cli/references/cli-command-usage.md
@@ -515,6 +515,10 @@ This is separate from boolean-flag parsing used by option arguments like `header
 - Description: Show summary statistics
 - Usage: `summary <var>`
 
+## `describe`
+- Description: Create a reusable summary DataTable
+- Usage: `describe <var> [by <col1>[,<col2>...]] [all true|false] [percentiles <p1,p2,...>] [as <var>]`
+
 ## `swap`
 - Description: Swap DataTable columns or rows
 - Usage: `swap <var> col|row <a> <b>`

--- a/skills/use-insyra-cli/references/cli-commands.md
+++ b/skills/use-insyra-cli/references/cli-commands.md
@@ -30,6 +30,7 @@ This list is generated from `insyra help` in this repository state.
 - `types` - Show value types of DataTable/DataList
 - `show` - Display data with optional range (supports negative and `_`)
 - `summary` - Show summary statistics
+- `describe` - Create a reusable summary DataTable
 
 ## Data Creation / IO
 - `newdl` - Create DataList manually
@@ -77,6 +78,7 @@ This list is generated from `insyra help` in this repository state.
 - `clean` - Clean values from DataTable/DataList
 - `merge` - Merge two DataTables
 - `groupby` - Group a DataTable and aggregate columns (split-apply-combine)
+- `describe` - Create DataList/DataTable or grouped summary tables
 - `pivot` - Reshape long-form DataTable to wide form (long -> wide)
 - `unpivot` - Reshape wide-form DataTable to long form (wide -> long)
 - `encode` - One-shot categorical encoding for DataTable variables


### PR DESCRIPTION
## Summary

- add programmatic Describe APIs for DataList, DataTable, and GroupedDataTable
- add IncludeAll and custom percentile support through DescribeOptions
- add CLI describe command with grouped summaries and saveable aliases
- update docs and agent skills; no isr wrapper was added

## Validation

- go test ./...