### PR TITLE
feat: fittable feature scalers (Standard/MinMax/Robust/MaxAbs)

### DIFF
--- a/Docs/DataTable.md
+++ b/Docs/DataTable.md
@@ -1049,6 +1049,105 @@ func main() {
 }
 ```
 
+### Feature Scaling
+
+```go
+func (dt *DataTable) StandardScale(cols ...string) (*DataTable, *StandardScaler, error)
+func (dt *DataTable) MinMaxScale(featureMin, featureMax float64, cols ...string) (*DataTable, *MinMaxScaler, error)
+func (dt *DataTable) RobustScale(cols ...string) (*DataTable, *RobustScaler, error)
+func (dt *DataTable) MaxAbsScale(cols ...string) (*DataTable, *MaxAbsScaler, error)
+```
+
+**Description:** Feature scalers fit numeric scaling parameters once and reuse them. Each method returns a fresh `*DataTable` (the receiver is not modified) plus a fitted scaler. The scaler can `Transform` and `InverseTransform` other tables with the same parameters.
+
+**Why this is not `DataList.Normalize` / `Standardize`:** `Normalize()` and `Standardize()` are stateless and modify the list in place — they recompute min/max or mean/std from whatever data they are handed. That is exactly what you must *not* do to a test set: scaling test data with its own statistics leaks information and makes train/test results incomparable. A `Scaler` fits on the **training** set and applies those frozen parameters to the test set, which is the correct, leakage-free workflow.
+
+**Choosing a scaler:**
+
+| Scaler | Centers on | Scales by | Use when |
+|---|---|---|---|
+| `StandardScaler` | mean | sample std dev (matches `Standardize`) | roughly Gaussian features; the common default |
+| `MinMaxScaler` | min | range, into `[featureMin, featureMax]` | you need a bounded range (e.g. `[0,1]`) and have few outliers |
+| `RobustScaler` | median | IQR (Q3−Q1) | features have outliers that would distort mean/std |
+| `MaxAbsScaler` | 0 | max absolute value, into `[-1,1]` | sparse or sign-meaningful data you don't want to shift |
+
+**Behavior:**
+
+- Column references resolve by name first, then Excel-style index (`"A"`, `"B"`, ...). `cols` is required.
+- Only the listed columns are scaled; other columns pass through unchanged, preserving column order, names, table name, and row names.
+- `nil` and `NaN` are preserved and excluded from fitting (they do not affect the computed parameters).
+- A non-numeric, non-missing value in a target column is an error.
+- `Transform` errors if a fitted column is missing from the input. `InverseTransform` only restores fitted columns that are present and passes others through (so a prediction table covering a subset still works).
+- Constant / degenerate columns (`std==0`, `max==min`, `IQR==0`, `maxAbs==0`) do not panic: the fitted training data maps to the degenerate output (`0`, or `featureMin` for min-max) and the inverse round-trips.
+
+**Interface and introspection:**
+
+```go
+type Scaler interface {
+    Fit(dt *DataTable, cols ...string) error
+    Transform(dt *DataTable) (*DataTable, error)
+    FitTransform(dt *DataTable, cols ...string) (*DataTable, error)
+    InverseTransform(dt *DataTable) (*DataTable, error)
+    Params() map[string]ScalerParams
+    Kind() string
+}
+
+func NewStandardScaler() *StandardScaler
+func NewMinMaxScaler(featureMin, featureMax float64) *MinMaxScaler
+func NewDefaultMinMaxScaler() *MinMaxScaler // [0, 1]
+func NewRobustScaler() *RobustScaler
+func NewMaxAbsScaler() *MaxAbsScaler
+```
+
+`Params()` returns the fitted parameters keyed by column name (`Mean`/`Std`, `Min`/`Max`/`OutputMin`/`OutputMax`, `Median`/`Q1`/`Q3`/`IQR`, or `MaxAbs` depending on the kind).
+
+There is also a DataList-oriented counterpart (`DataListScaler`) on every scaler: `FitDataList`, `TransformDataList`, `FitTransformDataList`, `InverseTransformDataList`, each returning a new `*DataList`.
+
+**Example — fit on train, transform test (no leakage):**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/HazelnutParadise/insyra"
+)
+
+func main() {
+    data := insyra.NewDataTable(
+        insyra.NewDataList(20.0, 30.0, 40.0, 50.0, 60.0).SetName("Age"),
+        insyra.NewDataList(30.0, 45.0, 50.0, 70.0, 90.0).SetName("Income"),
+    )
+    train, test := data.TrainTestSplit(0.8, insyra.SamplingOptions{UseSeed: true, Seed: 42})
+
+    // Fit the scaler on the training set only.
+    sc := insyra.NewStandardScaler()
+    trainScaled, err := sc.FitTransform(train, "Age", "Income")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Apply the SAME parameters to the test set.
+    testScaled, err := sc.Transform(test)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(sc.Params()["Age"]) // {Age standard <mean> <std> ...}
+    _ = trainScaled
+    _ = testScaled
+
+    // Recover the original scale (e.g. for predictions).
+    restored, err := sc.InverseTransform(trainScaled)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(restored.GetColByName("Age").Data())
+}
+```
+
 ### Window / sequence transforms (Shift / Diff / PctChange / Cum\* / Rolling / Expanding)
 
 ```go

--- a/Docs/cli-dsl.md
+++ b/Docs/cli-dsl.md
@@ -426,6 +426,31 @@ encode sales label segment newcol segment_id sortby freq keeporiginal true as la
 encode survey ordinal satisfaction order low,medium,high unknown error as ranked
 ```
 
+### B5. Feature scaling
+
+Unlike `encode`, `scale` is **stateful**: `scale fit` stores a reusable scaler variable, and `scale transform` / `scale inverse` apply that fitted scaler to any table. This lets you fit on a training set and transform a test set with the same parameters (no data leakage). Scaler variables live only for the session — they are not persisted to a named environment.
+
+```text
+scale fit std <scalerVar> <tableVar> cols <c1,c2,...>
+scale fit minmax <scalerVar> <tableVar> range <min> <max> cols <c1,c2,...>
+scale fit robust <scalerVar> <tableVar> cols <c1,c2,...>
+scale fit maxabs <scalerVar> <tableVar> cols <c1,c2,...>
+scale transform <scalerVar> <tableVar> as <outVar>
+scale inverse <scalerVar> <tableVar> as <outVar>
+```
+
+`minmax` defaults to `[0,1]` when `range` is omitted. `nil`/`NaN` are preserved and ignored when fitting; non-fitted columns pass through unchanged. `show <scalerVar>` prints the scaler kind and its fitted columns.
+
+Example (train/test without leakage):
+
+```text
+split dt train 0.8 as train test
+scale fit std sc train cols Age,Income
+scale transform sc train as train_scaled
+scale transform sc test as test_scaled
+scale inverse sc train_scaled as train_original
+```
+
 ### C. Go `engine/dsl` session flow
 
 ```go
@@ -465,7 +490,7 @@ High-level command map:
 - **Data IO / Creation**: `newdl`, `newdt`, `load`, `read`, `save`, `convert`
 - **Database**: `db` (`connect` / `list` / `tables` / `disconnect`), `load sql`, `save <var> sql`
 - **DataTable Structure / Access**: `addcol`, `addrow`, `dropcol`, `droprow`, `swap`, `transpose`, `rows`, `cols`, `row`, `col`, `get`, `set`, `setrownames`, `setcolnames`
-- **Data Processing**: `filter`, `sort`, `sample`, `split`, `find`, `replace`, `clean`, `fillna`, `merge`, `groupby`, `pivot`, `unpivot`, `encode`, `ccl`, `addcolccl`
+- **Data Processing**: `filter`, `sort`, `sample`, `split`, `find`, `replace`, `clean`, `fillna`, `merge`, `groupby`, `pivot`, `unpivot`, `encode`, `scale`, `ccl`, `addcolccl`
 - **DataList Stats**: `sum`, `mean`, `median`, `mode`, `stdev`, `var`, `min`, `max`, `range`, `quartile`, `iqr`, `percentile`, `count`, `counter`, `corr`, `cov`, `corrmatrix`, `skewness`, `kurtosis`
 - **Time Series / Transforms**: `rank`, `normalize`, `standardize`, `reverse`, `upper`, `lower`, `capitalize`, `parsenums`, `parsestrings`, `movavg`, `expsmooth`, `diff`, `diffn`, `shift`, `pctchange`, `cumsum`, `cumprod`, `cummax`, `cummin`, `rolling`, `expanding`, `fillna`
 - **Modeling / Viz / Fetch**: `regression`, `pca`, `kmeans`, `hclust`, `cutree`, `dbscan`, `silhouette`, `knn_classify`, `knn_regress`, `knn_neighbors`, `ttest`, `ztest`, `anova`, `ftest`, `chisq`, `plot`, `fetch`
@@ -588,6 +613,7 @@ Source policy:
 | `run` | `run <script.isr>` | Run DSL script file |
 | `sample` | `sample <var> <n>\|frac <frac>\|shuffle [replace true\|false] [seed N] [as <var>]` | Randomly sample or shuffle a DataList/DataTable |
 | `save` | `save <var> <file> [headers true\|false] [rownames true\|false] [bom true\|false] \| save <var> sql <conn> <table> [if-exists fail\|replace\|append] [batch N] [schema <s>] [rownames]` | Save a DataTable variable to a file or SQL connection |
+| `scale` | `scale fit std\|minmax\|robust\|maxabs <scalerVar> <tableVar> [range <min> <max>] cols <c1,c2,...> \| scale transform\|inverse <scalerVar> <tableVar> as <outVar>` | Fit a reusable feature scaler and transform/inverse tables with it |
 | `set` | `set <var> <row> <col> <value>` | Set single element in DataTable |
 | `setcolnames` | `setcolnames <var> <names...>` | Set DataTable column names |
 | `setrownames` | `setrownames <var> <names...>` | Set DataTable row names |

--- a/cli/commands/scale.go
+++ b/cli/commands/scale.go
@@ -1,0 +1,189 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	insyra "github.com/HazelnutParadise/insyra"
+)
+
+func init() {
+	_ = Register(&CommandHandler{
+		Name:        "scale",
+		Usage:       "scale fit std|minmax|robust|maxabs <scalerVar> <tableVar> [range <min> <max>] cols <c1,c2,...> | scale transform|inverse <scalerVar> <tableVar> as <outVar>",
+		Description: "Fit a reusable feature scaler and transform tables with it",
+		Forms: []string{
+			"scale fit std <scalerVar> <tableVar> cols <c1,c2,...>",
+			"scale fit minmax <scalerVar> <tableVar> range <min> <max> cols <c1,c2,...>",
+			"scale fit robust <scalerVar> <tableVar> cols <c1,c2,...>",
+			"scale fit maxabs <scalerVar> <tableVar> cols <c1,c2,...>",
+			"",
+			"scale transform <scalerVar> <tableVar> as <outVar>",
+			"scale inverse <scalerVar> <tableVar> as <outVar>",
+		},
+		Examples: []string{
+			"insyra split t train 0.8 as train test",
+			"insyra scale fit std sc train cols Age,Income",
+			"insyra scale transform sc train as train_scaled",
+			"insyra scale transform sc test as test_scaled",
+			"insyra scale inverse sc pred as pred_original",
+		},
+		Run: runScaleCommand,
+	})
+}
+
+func runScaleCommand(ctx *ExecContext, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: scale fit|transform|inverse ...")
+	}
+	switch strings.ToLower(args[0]) {
+	case "fit":
+		return runScaleFit(ctx, args[1:])
+	case "transform":
+		return runScaleApply(ctx, args[1:], false)
+	case "inverse":
+		return runScaleApply(ctx, args[1:], true)
+	default:
+		return fmt.Errorf("scale: unknown subcommand %q (supported: fit, transform, inverse)", args[0])
+	}
+}
+
+func runScaleFit(ctx *ExecContext, args []string) error {
+	if len(args) < 3 {
+		return fmt.Errorf("usage: scale fit <method> <scalerVar> <tableVar> [range <min> <max>] cols <c1,c2,...>")
+	}
+	method := strings.ToLower(args[0])
+	scalerVar := args[1]
+	tableVar := args[2]
+
+	cols, featureMin, featureMax, hasRange, err := parseScaleFitOptions(args[3:])
+	if err != nil {
+		return err
+	}
+	if len(cols) == 0 {
+		return fmt.Errorf("scale fit: cols is required (e.g. cols Age,Income)")
+	}
+
+	table, err := getDataTableVar(ctx, tableVar)
+	if err != nil {
+		return err
+	}
+
+	var scaler insyra.Scaler
+	switch method {
+	case "std", "standard":
+		scaler = insyra.NewStandardScaler()
+	case "minmax":
+		if !hasRange {
+			featureMin, featureMax = 0, 1
+		}
+		scaler = insyra.NewMinMaxScaler(featureMin, featureMax)
+	case "robust":
+		scaler = insyra.NewRobustScaler()
+	case "maxabs":
+		scaler = insyra.NewMaxAbsScaler()
+	default:
+		return fmt.Errorf("scale fit: unknown method %q (supported: std, minmax, robust, maxabs)", method)
+	}
+	if hasRange && method != "minmax" {
+		return fmt.Errorf("scale fit: range is only valid for minmax")
+	}
+
+	if err := scaler.Fit(table, cols...); err != nil {
+		return err
+	}
+	ctx.Vars[scalerVar] = scaler
+	_, _ = fmt.Fprintf(ctx.Output, "fitted %s scaler %s on %s (cols: %s)\n", scaler.Kind(), scalerVar, tableVar, strings.Join(scaledColumnNames(scaler), ", "))
+	return nil
+}
+
+func runScaleApply(ctx *ExecContext, args []string, inverse bool) error {
+	coreArgs, alias := parseAlias(args)
+	if len(coreArgs) != 2 {
+		op := "transform"
+		if inverse {
+			op = "inverse"
+		}
+		return fmt.Errorf("usage: scale %s <scalerVar> <tableVar> as <outVar>", op)
+	}
+	scaler, err := getScalerVar(ctx, coreArgs[0])
+	if err != nil {
+		return err
+	}
+	table, err := getDataTableVar(ctx, coreArgs[1])
+	if err != nil {
+		return err
+	}
+
+	var result *insyra.DataTable
+	if inverse {
+		result, err = scaler.InverseTransform(table)
+	} else {
+		result, err = scaler.Transform(table)
+	}
+	if err != nil {
+		return err
+	}
+	ctx.Vars[alias] = result
+	verb := "scaled"
+	if inverse {
+		verb = "inverse-scaled"
+	}
+	_, _ = fmt.Fprintf(ctx.Output, "%s %s into %s\n", verb, coreArgs[1], alias)
+	return nil
+}
+
+func parseScaleFitOptions(args []string) (cols []string, featureMin, featureMax float64, hasRange bool, err error) {
+	for i := 0; i < len(args); {
+		key := strings.ToLower(args[i])
+		switch key {
+		case "cols":
+			if i+1 >= len(args) {
+				return nil, 0, 0, false, fmt.Errorf("scale fit: option %q requires a value", args[i])
+			}
+			cols = parseCSVTokens(args[i+1])
+			i += 2
+		case "range":
+			if i+2 >= len(args) {
+				return nil, 0, 0, false, fmt.Errorf("scale fit: range requires <min> <max>")
+			}
+			featureMin, err = strconv.ParseFloat(args[i+1], 64)
+			if err != nil {
+				return nil, 0, 0, false, fmt.Errorf("scale fit: invalid range min %q", args[i+1])
+			}
+			featureMax, err = strconv.ParseFloat(args[i+2], 64)
+			if err != nil {
+				return nil, 0, 0, false, fmt.Errorf("scale fit: invalid range max %q", args[i+2])
+			}
+			hasRange = true
+			i += 3
+		default:
+			return nil, 0, 0, false, fmt.Errorf("scale fit: unknown option %q (supported: cols, range)", args[i])
+		}
+	}
+	return cols, featureMin, featureMax, hasRange, nil
+}
+
+func getScalerVar(ctx *ExecContext, name string) (insyra.Scaler, error) {
+	value, exists := ctx.Vars[name]
+	if !exists {
+		return nil, fmt.Errorf("variable not found: %s", name)
+	}
+	scaler, ok := value.(insyra.Scaler)
+	if !ok {
+		return nil, fmt.Errorf("variable %s is not a scaler (fit one with 'scale fit ...')", name)
+	}
+	return scaler, nil
+}
+
+func scaledColumnNames(scaler insyra.Scaler) []string {
+	params := scaler.Params()
+	names := make([]string, 0, len(params))
+	for name := range params {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cli/commands/scale_test.go
+++ b/cli/commands/scale_test.go
@@ -1,0 +1,133 @@
+package commands
+
+import (
+	"math"
+	"testing"
+
+	insyra "github.com/HazelnutParadise/insyra"
+)
+
+func scaleCLITable() *insyra.DataTable {
+	return insyra.NewDataTable(
+		insyra.NewDataList(1.0, 2.0, 3.0, 4.0).SetName("Age"),
+		insyra.NewDataList(10.0, 20.0, 30.0, 40.0).SetName("Income"),
+	)
+}
+
+func colFloats(t *testing.T, dt *insyra.DataTable, name string) []float64 {
+	t.Helper()
+	raw := dt.GetColByName(name).Data()
+	out := make([]float64, len(raw))
+	for i, v := range raw {
+		f, ok := insyra.ToFloat64Safe(v)
+		if !ok {
+			t.Fatalf("non-numeric %v at %d in %s", v, i, name)
+		}
+		out[i] = f
+	}
+	return out
+}
+
+func TestScaleCLIFitTransformInverseFlow(t *testing.T) {
+	ctx := newTestExecContext(t)
+	ctx.Vars["train"] = scaleCLITable()
+
+	if err := runScaleCommand(ctx, []string{"fit", "std", "sc", "train", "cols", "Age,Income"}); err != nil {
+		t.Fatalf("fit: %v", err)
+	}
+	if _, ok := ctx.Vars["sc"].(insyra.Scaler); !ok {
+		t.Fatalf("sc is not a scaler: %T", ctx.Vars["sc"])
+	}
+
+	if err := runScaleCommand(ctx, []string{"transform", "sc", "train", "as", "train_scaled"}); err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	scaled, ok := ctx.Vars["train_scaled"].(*insyra.DataTable)
+	if !ok {
+		t.Fatalf("train_scaled is not a DataTable")
+	}
+	var sum float64
+	for _, v := range colFloats(t, scaled, "Age") {
+		sum += v
+	}
+	if math.Abs(sum/4) > 1e-9 {
+		t.Fatalf("scaled Age mean = %v, want ~0", sum/4)
+	}
+
+	if err := runScaleCommand(ctx, []string{"inverse", "sc", "train_scaled", "as", "restored"}); err != nil {
+		t.Fatalf("inverse: %v", err)
+	}
+	restored := ctx.Vars["restored"].(*insyra.DataTable)
+	got := colFloats(t, restored, "Age")
+	want := []float64{1, 2, 3, 4}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 1e-9 {
+			t.Fatalf("restored Age = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestScaleCLIMinMaxRangeTrainTestNoLeakage(t *testing.T) {
+	ctx := newTestExecContext(t)
+	ctx.Vars["train"] = insyra.NewDataTable(insyra.NewDataList(0.0, 10.0).SetName("x"))
+	ctx.Vars["test"] = insyra.NewDataTable(insyra.NewDataList(5.0, 20.0).SetName("x"))
+
+	if err := runScaleCommand(ctx, []string{"fit", "minmax", "sc", "train", "range", "0", "1", "cols", "x"}); err != nil {
+		t.Fatalf("fit minmax: %v", err)
+	}
+	if err := runScaleCommand(ctx, []string{"transform", "sc", "test", "as", "test_scaled"}); err != nil {
+		t.Fatalf("transform test: %v", err)
+	}
+	out := ctx.Vars["test_scaled"].(*insyra.DataTable)
+	got := colFloats(t, out, "x")
+	// scaled with train min/max (0..10): 5 -> 0.5, 20 -> 2.0
+	if math.Abs(got[0]-0.5) > 1e-9 || math.Abs(got[1]-2.0) > 1e-9 {
+		t.Fatalf("test scaled = %v, want [0.5 2.0]", got)
+	}
+}
+
+func TestScaleCLIErrors(t *testing.T) {
+	ctx := newTestExecContext(t)
+	ctx.Vars["train"] = scaleCLITable()
+
+	// transform before fit -> scaler var not found
+	if err := runScaleCommand(ctx, []string{"transform", "sc", "train", "as", "out"}); err == nil {
+		t.Fatalf("expected error transforming with unknown scaler")
+	}
+
+	// fit without cols
+	if err := runScaleCommand(ctx, []string{"fit", "std", "sc", "train"}); err == nil {
+		t.Fatalf("expected error fitting without cols")
+	}
+
+	// fit on non-existent column
+	if err := runScaleCommand(ctx, []string{"fit", "std", "sc", "train", "cols", "Nope"}); err == nil {
+		t.Fatalf("expected error fitting unknown column")
+	}
+
+	// unknown method
+	if err := runScaleCommand(ctx, []string{"fit", "bogus", "sc", "train", "cols", "Age"}); err == nil {
+		t.Fatalf("expected error for unknown method")
+	}
+
+	// range on non-minmax
+	if err := runScaleCommand(ctx, []string{"fit", "std", "sc", "train", "range", "0", "1", "cols", "Age"}); err == nil {
+		t.Fatalf("expected error using range with std")
+	}
+
+	// unknown subcommand
+	if err := runScaleCommand(ctx, []string{"bogus"}); err == nil {
+		t.Fatalf("expected error for unknown subcommand")
+	}
+}
+
+func TestScaleCLIShowAndVars(t *testing.T) {
+	ctx := newTestExecContext(t)
+	ctx.Vars["train"] = scaleCLITable()
+	if err := runScaleCommand(ctx, []string{"fit", "robust", "sc", "train", "cols", "Age,Income"}); err != nil {
+		t.Fatalf("fit: %v", err)
+	}
+	if err := runShowCommand(ctx, []string{"sc"}); err != nil {
+		t.Fatalf("show scaler: %v", err)
+	}
+}

--- a/cli/commands/show.go
+++ b/cli/commands/show.go
@@ -2,7 +2,9 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
+	"strings"
 
 	insyra "github.com/HazelnutParadise/insyra"
 )
@@ -36,10 +38,23 @@ func runShowCommand(ctx *ExecContext, args []string) error {
 		typed.ShowRange(rangeArgs...)
 	case *insyra.DataList:
 		typed.ShowRange(rangeArgs...)
+	case insyra.Scaler:
+		return showScaler(ctx, args[0], typed)
 	default:
-		return fmt.Errorf("show is only supported for DataTable/DataList")
+		return fmt.Errorf("show is only supported for DataTable/DataList/scaler")
 	}
 
+	return nil
+}
+
+func showScaler(ctx *ExecContext, name string, scaler insyra.Scaler) error {
+	params := scaler.Params()
+	cols := make([]string, 0, len(params))
+	for col := range params {
+		cols = append(cols, col)
+	}
+	sort.Strings(cols)
+	_, _ = fmt.Fprintf(ctx.Output, "%s: %s scaler, fitted cols: %s\n", name, scaler.Kind(), strings.Join(cols, ", "))
 	return nil
 }
 

--- a/cli/env/state.go
+++ b/cli/env/state.go
@@ -31,6 +31,11 @@ func (m *Manager) SaveState(envName string, vars map[string]any) error {
 		LastAccess: time.Now().UTC().Format(time.RFC3339),
 	}
 	for key, value := range vars {
+		// Scalers hold fitted state in unexported fields and cannot be
+		// round-tripped through JSON; they are session-only.
+		if _, ok := value.(insyra.Scaler); ok {
+			continue
+		}
 		state.Variables[key] = serializeVariable(value)
 	}
 	payload, err := json.MarshalIndent(state, "", "  ")

--- a/datatable_scale.go
+++ b/datatable_scale.go
@@ -1,0 +1,536 @@
+package insyra
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+// ScalerParams reports the fitted parameters for a single scaled column.
+// Only the fields relevant to the scaler kind are populated; the rest stay
+// at their zero value.
+type ScalerParams struct {
+	Column string
+	Kind   string
+
+	Mean   float64
+	Std    float64
+	Min    float64
+	Max    float64
+	Median float64
+	Q1     float64
+	Q3     float64
+	IQR    float64
+	MaxAbs float64
+
+	OutputMin float64
+	OutputMax float64
+}
+
+// Scaler is the shared surface for fitted, reusable feature scalers.
+//
+// Unlike DataList.Normalize/Standardize (stateless, in-place), a Scaler fits
+// parameters once and can Transform/InverseTransform new tables with the same
+// parameters, which is the correct way to scale a test set with statistics
+// learned from the training set (no data leakage).
+type Scaler interface {
+	Fit(dt *DataTable, cols ...string) error
+	Transform(dt *DataTable) (*DataTable, error)
+	FitTransform(dt *DataTable, cols ...string) (*DataTable, error)
+	InverseTransform(dt *DataTable) (*DataTable, error)
+	Params() map[string]ScalerParams
+	Kind() string
+}
+
+// DataListScaler is the DataList-oriented counterpart of Scaler.
+type DataListScaler interface {
+	FitDataList(dl *DataList) error
+	TransformDataList(dl *DataList) (*DataList, error)
+	FitTransformDataList(dl *DataList) (*DataList, error)
+	InverseTransformDataList(dl *DataList) (*DataList, error)
+}
+
+// scalerColumn holds the fitted state for one column. Every scaler reduces to
+// the affine map y = (x-center)/scale*gain + offset, with the inverse
+// x = (y-offset)/gain*scale + center. Degenerate inputs set scale = 1 so the
+// transform never divides by zero and never panics.
+type scalerColumn struct {
+	ref    string
+	name   string
+	params ScalerParams
+
+	center float64
+	scale  float64
+	gain   float64
+	offset float64
+}
+
+// scaler is the embedded base shared by all concrete scalers. The concrete
+// type only carries the kind tag and (for min-max) the feature range.
+type scaler struct {
+	kind       string
+	featureMin float64
+	featureMax float64
+
+	cols   []scalerColumn
+	fitted bool
+}
+
+// StandardScaler scales columns to zero mean and unit (sample) standard
+// deviation, matching DataList.Standardize's use of the sample stdev.
+type StandardScaler struct{ scaler }
+
+// MinMaxScaler scales columns into a [featureMin, featureMax] range.
+type MinMaxScaler struct{ scaler }
+
+// RobustScaler centers on the median and scales by the IQR, making it robust
+// to outliers.
+type RobustScaler struct{ scaler }
+
+// MaxAbsScaler scales each column by its maximum absolute value, preserving
+// sign and mapping data into [-1, 1].
+type MaxAbsScaler struct{ scaler }
+
+// NewStandardScaler returns an unfitted standard scaler.
+func NewStandardScaler() *StandardScaler { return &StandardScaler{scaler{kind: "standard"}} }
+
+// NewMinMaxScaler returns an unfitted min-max scaler targeting the given range.
+func NewMinMaxScaler(featureMin, featureMax float64) *MinMaxScaler {
+	return &MinMaxScaler{scaler{kind: "minmax", featureMin: featureMin, featureMax: featureMax}}
+}
+
+// NewDefaultMinMaxScaler returns a min-max scaler targeting [0, 1].
+func NewDefaultMinMaxScaler() *MinMaxScaler { return NewMinMaxScaler(0, 1) }
+
+// NewRobustScaler returns an unfitted robust scaler.
+func NewRobustScaler() *RobustScaler { return &RobustScaler{scaler{kind: "robust"}} }
+
+// NewMaxAbsScaler returns an unfitted max-abs scaler.
+func NewMaxAbsScaler() *MaxAbsScaler { return &MaxAbsScaler{scaler{kind: "maxabs"}} }
+
+// StandardScale fits a StandardScaler on cols and returns the scaled table.
+func (dt *DataTable) StandardScale(cols ...string) (*DataTable, *StandardScaler, error) {
+	sc := NewStandardScaler()
+	out, err := sc.FitTransform(dt, cols...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, sc, nil
+}
+
+// MinMaxScale fits a MinMaxScaler on cols and returns the scaled table.
+func (dt *DataTable) MinMaxScale(featureMin, featureMax float64, cols ...string) (*DataTable, *MinMaxScaler, error) {
+	sc := NewMinMaxScaler(featureMin, featureMax)
+	out, err := sc.FitTransform(dt, cols...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, sc, nil
+}
+
+// RobustScale fits a RobustScaler on cols and returns the scaled table.
+func (dt *DataTable) RobustScale(cols ...string) (*DataTable, *RobustScaler, error) {
+	sc := NewRobustScaler()
+	out, err := sc.FitTransform(dt, cols...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, sc, nil
+}
+
+// MaxAbsScale fits a MaxAbsScaler on cols and returns the scaled table.
+func (dt *DataTable) MaxAbsScale(cols ...string) (*DataTable, *MaxAbsScaler, error) {
+	sc := NewMaxAbsScaler()
+	out, err := sc.FitTransform(dt, cols...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, sc, nil
+}
+
+// Kind returns the scaler family name ("standard", "minmax", "robust", "maxabs").
+func (s *scaler) Kind() string { return s.kind }
+
+// Params returns the fitted parameters keyed by output column name.
+func (s *scaler) Params() map[string]ScalerParams {
+	out := make(map[string]ScalerParams, len(s.cols))
+	for _, c := range s.cols {
+		out[c.name] = c.params
+	}
+	return out
+}
+
+// Fit learns scaling parameters from the given columns without modifying dt.
+// cols is required; pass at least one column reference (name or Excel-style
+// index such as "A").
+func (s *scaler) Fit(dt *DataTable, cols ...string) error {
+	if dt == nil {
+		return fmt.Errorf("%sScaler.Fit: table is nil", s.kind)
+	}
+	if len(cols) == 0 {
+		return fmt.Errorf("%sScaler.Fit: at least one column is required", s.kind)
+	}
+	fitted := make([]scalerColumn, 0, len(cols))
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		seen := map[int]struct{}{}
+		for _, ref := range cols {
+			idx, label, ok := resolveEncodingColumn(t, ref)
+			if !ok {
+				err = fmt.Errorf("%sScaler.Fit: column %q not found", s.kind, ref)
+				return
+			}
+			if _, dup := seen[idx]; dup {
+				err = fmt.Errorf("%sScaler.Fit: column %q listed more than once", s.kind, ref)
+				return
+			}
+			seen[idx] = struct{}{}
+
+			name := label
+			if t.columns[idx].name != "" {
+				name = t.columns[idx].name
+			}
+			var vals []float64
+			vals, err = numericColumnValues(t.columns[idx].data, s.kind+"Scaler.Fit")
+			if err != nil {
+				return
+			}
+			fitted = append(fitted, s.computeColumn(label, name, vals))
+		}
+	})
+	if err != nil {
+		return err
+	}
+	s.cols = fitted
+	s.fitted = true
+	return nil
+}
+
+// FitTransform fits on cols and immediately returns the scaled table.
+func (s *scaler) FitTransform(dt *DataTable, cols ...string) (*DataTable, error) {
+	if err := s.Fit(dt, cols...); err != nil {
+		return nil, err
+	}
+	return s.Transform(dt)
+}
+
+// Transform applies the fitted parameters to dt and returns a new table.
+// The original table is not modified. Unfitted columns pass through unchanged.
+// A fitted column missing from dt is an error.
+func (s *scaler) Transform(dt *DataTable) (*DataTable, error) {
+	return s.apply(dt, false)
+}
+
+// InverseTransform restores the original scale of fitted columns and returns a
+// new table. Unfitted columns pass through unchanged; fitted columns absent
+// from dt are simply skipped (so predictions covering a subset still work).
+func (s *scaler) InverseTransform(dt *DataTable) (*DataTable, error) {
+	return s.apply(dt, true)
+}
+
+func (s *scaler) apply(dt *DataTable, inverse bool) (*DataTable, error) {
+	op := "Transform"
+	if inverse {
+		op = "InverseTransform"
+	}
+	if !s.fitted {
+		return nil, fmt.Errorf("%sScaler.%s: scaler is not fitted", s.kind, op)
+	}
+	if dt == nil {
+		return nil, fmt.Errorf("%sScaler.%s: table is nil", s.kind, op)
+	}
+	out := NewDataTable()
+	var err error
+	dt.AtomicDo(func(t *DataTable) {
+		colByIndex := map[int]*scalerColumn{}
+		for i := range s.cols {
+			idx, _, ok := resolveEncodingColumn(t, s.cols[i].ref)
+			if !ok {
+				if inverse {
+					continue
+				}
+				err = fmt.Errorf("%sScaler.%s: fitted column %q not found", s.kind, op, s.cols[i].ref)
+				return
+			}
+			colByIndex[idx] = &s.cols[i]
+		}
+		outCols := make([]*DataList, 0, len(t.columns))
+		for idx, col := range t.columns {
+			c, scaled := colByIndex[idx]
+			if !scaled {
+				outCols = append(outCols, col.Clone())
+				continue
+			}
+			var transformed *DataList
+			transformed, err = s.applyColumn(c, col.name, col.data, inverse, op)
+			if err != nil {
+				return
+			}
+			outCols = append(outCols, transformed)
+		}
+		out.AppendCols(outCols...)
+		copyRowNamesNotAtomic(out, t)
+		out.name = t.name
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *scaler) applyColumn(c *scalerColumn, name string, data []any, inverse bool, op string) (*DataList, error) {
+	dst := NewDataList()
+	dst.SetName(name)
+	for _, raw := range data {
+		if isNilOrNaN(raw) {
+			dst.Append(raw)
+			continue
+		}
+		x, ok := ToFloat64Safe(raw)
+		if !ok {
+			return nil, fmt.Errorf("%sScaler.%s: column %q has non-numeric value %v", s.kind, op, c.name, raw)
+		}
+		var y float64
+		if inverse {
+			y = (x-c.offset)/c.gain*c.scale + c.center
+		} else {
+			y = (x-c.center)/c.scale*c.gain + c.offset
+		}
+		dst.Append(y)
+	}
+	return dst, nil
+}
+
+// computeColumn turns a column's numeric values into fitted parameters and the
+// affine coefficients used by apply. Degenerate spreads set scale = 1.
+func (s *scaler) computeColumn(ref, name string, vals []float64) scalerColumn {
+	c := scalerColumn{ref: ref, name: name}
+	c.params.Column = name
+	c.params.Kind = s.kind
+	c.gain = 1
+	c.offset = 0
+
+	switch s.kind {
+	case "standard":
+		mean := meanOf(vals)
+		std := sampleStdOf(vals, mean)
+		c.params.Mean = mean
+		c.params.Std = std
+		c.center = mean
+		c.scale = nonZero(std)
+	case "minmax":
+		min, max := minMaxOf(vals)
+		c.params.Min = min
+		c.params.Max = max
+		c.params.OutputMin = s.featureMin
+		c.params.OutputMax = s.featureMax
+		c.center = min
+		c.scale = nonZero(max - min)
+		c.gain = s.featureMax - s.featureMin
+		c.offset = s.featureMin
+	case "robust":
+		sorted := append([]float64(nil), vals...)
+		sort.Float64s(sorted)
+		q1 := quantileQuartile(sorted, 0.25)
+		median := quantileQuartile(sorted, 0.5)
+		q3 := quantileQuartile(sorted, 0.75)
+		iqr := q3 - q1
+		c.params.Median = median
+		c.params.Q1 = q1
+		c.params.Q3 = q3
+		c.params.IQR = iqr
+		c.center = median
+		c.scale = nonZero(iqr)
+	case "maxabs":
+		maxAbs := maxAbsOf(vals)
+		c.params.MaxAbs = maxAbs
+		c.center = 0
+		c.scale = nonZero(maxAbs)
+	}
+	return c
+}
+
+// FitDataList learns scaling parameters from a single DataList.
+func (s *scaler) FitDataList(dl *DataList) error {
+	if dl == nil {
+		return fmt.Errorf("%sScaler.FitDataList: list is nil", s.kind)
+	}
+	var fitted scalerColumn
+	var err error
+	dl.AtomicDo(func(d *DataList) {
+		var vals []float64
+		vals, err = numericColumnValues(d.data, s.kind+"Scaler.FitDataList")
+		if err != nil {
+			return
+		}
+		fitted = s.computeColumn(d.name, d.name, vals)
+	})
+	if err != nil {
+		return err
+	}
+	s.cols = []scalerColumn{fitted}
+	s.fitted = true
+	return nil
+}
+
+// FitTransformDataList fits on dl and returns a new scaled DataList.
+func (s *scaler) FitTransformDataList(dl *DataList) (*DataList, error) {
+	if err := s.FitDataList(dl); err != nil {
+		return nil, err
+	}
+	return s.TransformDataList(dl)
+}
+
+// TransformDataList scales dl using the fitted parameters, returning a new
+// DataList. The original list is not modified.
+func (s *scaler) TransformDataList(dl *DataList) (*DataList, error) {
+	return s.applyList(dl, false)
+}
+
+// InverseTransformDataList restores the original scale of dl, returning a new
+// DataList.
+func (s *scaler) InverseTransformDataList(dl *DataList) (*DataList, error) {
+	return s.applyList(dl, true)
+}
+
+func (s *scaler) applyList(dl *DataList, inverse bool) (*DataList, error) {
+	op := "TransformDataList"
+	if inverse {
+		op = "InverseTransformDataList"
+	}
+	if !s.fitted || len(s.cols) == 0 {
+		return nil, fmt.Errorf("%sScaler.%s: scaler is not fitted", s.kind, op)
+	}
+	if dl == nil {
+		return nil, fmt.Errorf("%sScaler.%s: list is nil", s.kind, op)
+	}
+	c := &s.cols[0]
+	var out *DataList
+	var err error
+	dl.AtomicDo(func(d *DataList) {
+		out, err = s.applyColumn(c, d.name, d.data, inverse, op)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// numericColumnValues extracts numeric values, skipping nil/NaN. A non-numeric,
+// non-missing value is an error (scalers only apply to numeric columns).
+func numericColumnValues(data []any, method string) ([]float64, error) {
+	vals := make([]float64, 0, len(data))
+	for _, raw := range data {
+		if isNilOrNaN(raw) {
+			continue
+		}
+		f, ok := ToFloat64Safe(raw)
+		if !ok {
+			return nil, fmt.Errorf("%s: non-numeric value %v", method, raw)
+		}
+		vals = append(vals, f)
+	}
+	return vals, nil
+}
+
+func nonZero(v float64) float64 {
+	if v == 0 || math.IsNaN(v) {
+		return 1
+	}
+	return v
+}
+
+func meanOf(vals []float64) float64 {
+	if len(vals) == 0 {
+		return math.NaN()
+	}
+	var sum float64
+	for _, v := range vals {
+		sum += v
+	}
+	return sum / float64(len(vals))
+}
+
+// sampleStdOf mirrors DataList.Stdev (sample standard deviation, ddof=1).
+// Fewer than two values yields 0 (treated as a degenerate, constant column).
+func sampleStdOf(vals []float64, mean float64) float64 {
+	if len(vals) < 2 {
+		return 0
+	}
+	var ss float64
+	for _, v := range vals {
+		d := v - mean
+		ss += d * d
+	}
+	return math.Sqrt(ss / float64(len(vals)-1))
+}
+
+func minMaxOf(vals []float64) (float64, float64) {
+	if len(vals) == 0 {
+		return math.NaN(), math.NaN()
+	}
+	min, max := vals[0], vals[0]
+	for _, v := range vals[1:] {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return min, max
+}
+
+func maxAbsOf(vals []float64) float64 {
+	var m float64
+	for _, v := range vals {
+		if a := math.Abs(v); a > m {
+			m = a
+		}
+	}
+	return m
+}
+
+// quantileQuartile mirrors DataList.Quartile's p*(n+1) positioning so the
+// RobustScaler's quartiles match the library's IQR().
+func quantileQuartile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return math.NaN()
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	pos := p * float64(n+1)
+	if pos < 1.0 {
+		pos = 1.0
+	} else if pos > float64(n) {
+		pos = float64(n)
+	}
+	lower := int(math.Floor(pos)) - 1
+	upper := int(math.Ceil(pos)) - 1
+	if lower < 0 {
+		lower = 0
+	}
+	if upper >= n {
+		upper = n - 1
+	}
+	if lower == upper {
+		return sorted[lower]
+	}
+	frac := pos - math.Floor(pos)
+	return sorted[lower] + frac*(sorted[upper]-sorted[lower])
+}
+
+// compile-time interface checks
+var (
+	_ Scaler = (*StandardScaler)(nil)
+	_ Scaler = (*MinMaxScaler)(nil)
+	_ Scaler = (*RobustScaler)(nil)
+	_ Scaler = (*MaxAbsScaler)(nil)
+
+	_ DataListScaler = (*StandardScaler)(nil)
+	_ DataListScaler = (*MinMaxScaler)(nil)
+	_ DataListScaler = (*RobustScaler)(nil)
+	_ DataListScaler = (*MaxAbsScaler)(nil)
+)

--- a/datatable_scale_test.go
+++ b/datatable_scale_test.go
@@ -1,0 +1,375 @@
+package insyra
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func scaleTestTable() *DataTable {
+	return NewDataTable(
+		NewDataList(1.0, 2.0, 3.0, 4.0).SetName("age"),
+		NewDataList(10.0, 20.0, 30.0, 40.0).SetName("income"),
+		NewDataList("a", "b", "c", "d").SetName("label"),
+	)
+}
+
+func floatsOf(t *testing.T, dl *DataList) []float64 {
+	t.Helper()
+	if dl == nil {
+		t.Fatalf("got nil DataList")
+	}
+	raw := dl.Data()
+	out := make([]float64, len(raw))
+	for i, v := range raw {
+		f, ok := ToFloat64Safe(v)
+		if !ok {
+			t.Fatalf("value %v at %d is not numeric", v, i)
+		}
+		out[i] = f
+	}
+	return out
+}
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func assertApproxSlice(t *testing.T, got []float64, want []float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range got {
+		if !approx(got[i], want[i]) {
+			t.Fatalf("at %d: got %v, want %v (full %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// --- StandardScaler ---
+
+func TestStandardScalerFitParamsAndRoundTrip(t *testing.T) {
+	dt := scaleTestTable()
+	out, sc, err := dt.StandardScale("age")
+	if err != nil {
+		t.Fatalf("StandardScale: %v", err)
+	}
+	p := sc.Params()["age"]
+	if !approx(p.Mean, 2.5) {
+		t.Fatalf("mean = %v, want 2.5", p.Mean)
+	}
+	// sample stdev of 1,2,3,4 = sqrt(5/3)
+	wantStd := math.Sqrt(5.0 / 3.0)
+	if !approx(p.Std, wantStd) {
+		t.Fatalf("std = %v, want %v", p.Std, wantStd)
+	}
+	got := floatsOf(t, out.GetColByName("age"))
+	var sum float64
+	for _, v := range got {
+		sum += v
+	}
+	if !approx(sum/float64(len(got)), 0) {
+		t.Fatalf("scaled mean = %v, want ~0", sum/float64(len(got)))
+	}
+	// untouched columns pass through
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("income")), []float64{10, 20, 30, 40})
+	// original is unchanged
+	assertApproxSlice(t, floatsOf(t, dt.GetColByName("age")), []float64{1, 2, 3, 4})
+
+	back, err := sc.InverseTransform(out)
+	if err != nil {
+		t.Fatalf("InverseTransform: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, back.GetColByName("age")), []float64{1, 2, 3, 4})
+}
+
+func TestStandardScalerConstantColumnNoPanic(t *testing.T) {
+	dt := NewDataTable(NewDataList(5.0, 5.0, 5.0).SetName("c"))
+	out, sc, err := dt.StandardScale("c")
+	if err != nil {
+		t.Fatalf("StandardScale constant: %v", err)
+	}
+	if p := sc.Params()["c"]; !approx(p.Std, 0) {
+		t.Fatalf("std = %v, want 0", p.Std)
+	}
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("c")), []float64{0, 0, 0})
+}
+
+// --- MinMaxScaler ---
+
+func TestMinMaxScalerDefaultAndCustomRange(t *testing.T) {
+	dt := scaleTestTable()
+	out, sc, err := dt.MinMaxScale(0, 1, "age")
+	if err != nil {
+		t.Fatalf("MinMaxScale: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("age")), []float64{0, 1.0 / 3, 2.0 / 3, 1})
+	if p := sc.Params()["age"]; !approx(p.Min, 1) || !approx(p.Max, 4) {
+		t.Fatalf("min/max = %v/%v", p.Min, p.Max)
+	}
+	back, err := sc.InverseTransform(out)
+	if err != nil {
+		t.Fatalf("inverse: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, back.GetColByName("age")), []float64{1, 2, 3, 4})
+
+	out2, _, err := dt.MinMaxScale(-1, 1, "age")
+	if err != nil {
+		t.Fatalf("MinMaxScale custom: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, out2.GetColByName("age")), []float64{-1, -1.0 / 3, 1.0 / 3, 1})
+}
+
+func TestMinMaxScalerConstantColumnOutputsFeatureMin(t *testing.T) {
+	dt := NewDataTable(NewDataList(7.0, 7.0, 7.0).SetName("c"))
+	out, _, err := dt.MinMaxScale(0, 1, "c")
+	if err != nil {
+		t.Fatalf("MinMaxScale constant: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("c")), []float64{0, 0, 0})
+
+	out2, _, err := NewDataTable(NewDataList(7.0, 7.0).SetName("c")).MinMaxScale(2, 5, "c")
+	if err != nil {
+		t.Fatalf("MinMaxScale constant range: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, out2.GetColByName("c")), []float64{2, 2})
+}
+
+// --- RobustScaler ---
+
+func TestRobustScalerParamsAndRoundTrip(t *testing.T) {
+	// 1..5 : median 3, Q1 (p*(n+1)=0.25*6=1.5 -> between idx0,1) = 1.5, Q3 = 4.5, IQR = 3
+	dt := NewDataTable(NewDataList(1.0, 2.0, 3.0, 4.0, 5.0).SetName("x"))
+	out, sc, err := dt.RobustScale("x")
+	if err != nil {
+		t.Fatalf("RobustScale: %v", err)
+	}
+	p := sc.Params()["x"]
+	if !approx(p.Median, 3) || !approx(p.Q1, 1.5) || !approx(p.Q3, 4.5) || !approx(p.IQR, 3) {
+		t.Fatalf("params = %+v", p)
+	}
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("x")),
+		[]float64{(1 - 3) / 3.0, (2 - 3) / 3.0, 0, (4 - 3) / 3.0, (5 - 3) / 3.0})
+	back, err := sc.InverseTransform(out)
+	if err != nil {
+		t.Fatalf("inverse: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, back.GetColByName("x")), []float64{1, 2, 3, 4, 5})
+}
+
+func TestRobustScalerOutlierStabilityAndConstant(t *testing.T) {
+	base := []any{1.0, 2.0, 3.0, 4.0, 5.0}
+	withOutlier := append(append([]any{}, base...), 1000.0)
+	pBase := NewRobustScaler()
+	if err := pBase.FitDataList(NewDataList(base...)); err != nil {
+		t.Fatalf("fit base: %v", err)
+	}
+	pOut := NewRobustScaler()
+	if err := pOut.FitDataList(NewDataList(withOutlier...)); err != nil {
+		t.Fatalf("fit outlier: %v", err)
+	}
+	// median should remain stable (3 vs 3.5), unlike a mean which would blow up
+	if m := pOut.Params()[""].Median; m > 4 {
+		t.Fatalf("median moved too far with outlier: %v", m)
+	}
+
+	dt := NewDataTable(NewDataList(2.0, 2.0, 2.0).SetName("c"))
+	out, _, err := dt.RobustScale("c")
+	if err != nil {
+		t.Fatalf("RobustScale constant: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("c")), []float64{0, 0, 0})
+}
+
+// --- MaxAbsScaler ---
+
+func TestMaxAbsScalerSignAndRoundTrip(t *testing.T) {
+	dt := NewDataTable(NewDataList(-4.0, -2.0, 0.0, 2.0).SetName("x"))
+	out, sc, err := dt.MaxAbsScale("x")
+	if err != nil {
+		t.Fatalf("MaxAbsScale: %v", err)
+	}
+	if p := sc.Params()["x"]; !approx(p.MaxAbs, 4) {
+		t.Fatalf("maxabs = %v", p.MaxAbs)
+	}
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("x")), []float64{-1, -0.5, 0, 0.5})
+	back, err := sc.InverseTransform(out)
+	if err != nil {
+		t.Fatalf("inverse: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, back.GetColByName("x")), []float64{-4, -2, 0, 2})
+}
+
+func TestMaxAbsScalerAllZeroNoPanic(t *testing.T) {
+	dt := NewDataTable(NewDataList(0.0, 0.0, 0.0).SetName("c"))
+	out, _, err := dt.MaxAbsScale("c")
+	if err != nil {
+		t.Fatalf("MaxAbsScale zero: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("c")), []float64{0, 0, 0})
+}
+
+// --- DataTable behavior ---
+
+func TestScalerTransformOnlyFittedColsAndPreservesShape(t *testing.T) {
+	dt := scaleTestTable()
+	dt.SetName("data")
+	dt.SetRowNameByIndex(0, "r0")
+	dt.SetRowNameByIndex(3, "r3")
+
+	out, _, err := dt.MinMaxScale(0, 1, "age")
+	if err != nil {
+		t.Fatalf("MinMaxScale: %v", err)
+	}
+	// column order and names preserved
+	if got := out.ColNames(); !reflect.DeepEqual(got, []string{"age", "income", "label"}) {
+		t.Fatalf("cols = %v", got)
+	}
+	// non-fitted numeric column untouched
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("income")), []float64{10, 20, 30, 40})
+	// non-numeric column passes through
+	if got := out.GetColByName("label").Data(); !reflect.DeepEqual(got, []any{"a", "b", "c", "d"}) {
+		t.Fatalf("label = %v", got)
+	}
+	// table name + row names preserved
+	if out.GetName() != "data" {
+		t.Fatalf("table name = %q", out.GetName())
+	}
+	if n, ok := out.GetRowNameByIndex(0); !ok || n != "r0" {
+		t.Fatalf("row name 0 = %q ok=%v", n, ok)
+	}
+}
+
+func TestScalerTrainTestUsesTrainParams(t *testing.T) {
+	train := NewDataTable(NewDataList(0.0, 10.0).SetName("x")) // min 0, max 10
+	test := NewDataTable(NewDataList(5.0, 20.0).SetName("x"))
+
+	sc := NewMinMaxScaler(0, 1)
+	if _, err := sc.FitTransform(train, "x"); err != nil {
+		t.Fatalf("fit train: %v", err)
+	}
+	out, err := sc.Transform(test)
+	if err != nil {
+		t.Fatalf("transform test: %v", err)
+	}
+	// test scaled with TRAIN min/max (0..10), so 5 -> 0.5, 20 -> 2.0 (not re-fit to 1.0)
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("x")), []float64{0.5, 2.0})
+}
+
+func TestScalerTransformMissingFittedColumnErrors(t *testing.T) {
+	dt := scaleTestTable()
+	sc := NewStandardScaler()
+	if err := sc.Fit(dt, "age"); err != nil {
+		t.Fatalf("fit: %v", err)
+	}
+	other := NewDataTable(NewDataList(1.0, 2.0).SetName("income"))
+	if _, err := sc.Transform(other); err == nil {
+		t.Fatalf("expected error for missing fitted column")
+	}
+}
+
+func TestScalerNonNumericColumnErrors(t *testing.T) {
+	dt := scaleTestTable()
+	sc := NewStandardScaler()
+	if err := sc.Fit(dt, "label"); err == nil {
+		t.Fatalf("expected error fitting non-numeric column")
+	}
+}
+
+func TestScalerNaNAndNilPreserved(t *testing.T) {
+	dt := NewDataTable(NewDataList(1.0, math.NaN(), nil, 3.0).SetName("x"))
+	out, sc, err := dt.MinMaxScale(0, 1, "x")
+	if err != nil {
+		t.Fatalf("MinMaxScale: %v", err)
+	}
+	// fit ignores NaN/nil -> min 1, max 3
+	if p := sc.Params()["x"]; !approx(p.Min, 1) || !approx(p.Max, 3) {
+		t.Fatalf("params = %+v", p)
+	}
+	data := out.GetColByName("x").Data()
+	if f, _ := ToFloat64Safe(data[0]); !approx(f, 0) {
+		t.Fatalf("data[0] = %v, want 0", data[0])
+	}
+	if f, ok := data[1].(float64); !ok || !math.IsNaN(f) {
+		t.Fatalf("data[1] = %v, want NaN preserved", data[1])
+	}
+	if data[2] != nil {
+		t.Fatalf("data[2] = %v, want nil preserved", data[2])
+	}
+	if f, _ := ToFloat64Safe(data[3]); !approx(f, 1) {
+		t.Fatalf("data[3] = %v, want 1", data[3])
+	}
+}
+
+func TestScalerExcelStyleColumnRef(t *testing.T) {
+	dt := scaleTestTable()
+	// "B" -> second column = income
+	out, sc, err := dt.MinMaxScale(0, 1, "B")
+	if err != nil {
+		t.Fatalf("MinMaxScale by index: %v", err)
+	}
+	if _, ok := sc.Params()["income"]; !ok {
+		t.Fatalf("params keyed by %v, want income", sc.Params())
+	}
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("income")), []float64{0, 1.0 / 3, 2.0 / 3, 1})
+	// age untouched
+	assertApproxSlice(t, floatsOf(t, out.GetColByName("age")), []float64{1, 2, 3, 4})
+}
+
+func TestScalerFitRequiresColumns(t *testing.T) {
+	dt := scaleTestTable()
+	sc := NewStandardScaler()
+	if err := sc.Fit(dt); err == nil {
+		t.Fatalf("expected error when no columns given")
+	}
+}
+
+func TestScalerTransformBeforeFitErrors(t *testing.T) {
+	dt := scaleTestTable()
+	sc := NewStandardScaler()
+	if _, err := sc.Transform(dt); err == nil {
+		t.Fatalf("expected error transforming before fit")
+	}
+}
+
+// --- DataList API ---
+
+func TestDataListScalerFitTransformReturnsNewList(t *testing.T) {
+	dl := NewDataList(1.0, 2.0, 3.0, 4.0).SetName("x")
+	sc := NewStandardScaler()
+	out, err := sc.FitTransformDataList(dl)
+	if err != nil {
+		t.Fatalf("FitTransformDataList: %v", err)
+	}
+	// original unchanged
+	assertApproxSlice(t, floatsOf(t, dl), []float64{1, 2, 3, 4})
+	// out has zero mean
+	var sum float64
+	for _, v := range floatsOf(t, out) {
+		sum += v
+	}
+	if !approx(sum/4, 0) {
+		t.Fatalf("scaled mean = %v", sum/4)
+	}
+	if out.GetName() != "x" {
+		t.Fatalf("name = %q, want x", out.GetName())
+	}
+	back, err := sc.InverseTransformDataList(out)
+	if err != nil {
+		t.Fatalf("InverseTransformDataList: %v", err)
+	}
+	assertApproxSlice(t, floatsOf(t, back), []float64{1, 2, 3, 4})
+}
+
+func TestKindReporting(t *testing.T) {
+	cases := map[string]Scaler{
+		"standard": NewStandardScaler(),
+		"minmax":   NewDefaultMinMaxScaler(),
+		"robust":   NewRobustScaler(),
+		"maxabs":   NewMaxAbsScaler(),
+	}
+	for want, sc := range cases {
+		if got := sc.Kind(); got != want {
+			t.Fatalf("Kind = %q, want %q", got, want)
+		}
+	}
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -306,6 +306,12 @@ type IDataTable interface {
 	LabelEncode(opts LabelEncodeOptions) (*DataTable, *LabelEncoder, error)
 	OrdinalEncode(opts OrdinalEncodeOptions) (*DataTable, *OrdinalEncoder, error)
 
+	// Scaling
+	StandardScale(cols ...string) (*DataTable, *StandardScaler, error)
+	MinMaxScale(featureMin, featureMax float64, cols ...string) (*DataTable, *MinMaxScaler, error)
+	RobustScale(cols ...string) (*DataTable, *RobustScaler, error)
+	MaxAbsScale(cols ...string) (*DataTable, *MaxAbsScaler, error)
+
 	ReplaceInRow(rowIndex int, oldValue, newValue any, mode ...int) *DataTable
 	ReplaceNaNsInRow(rowIndex int, newValue any, mode ...int) *DataTable
 	ReplaceNilsInRow(rowIndex int, newValue any, mode ...int) *DataTable

--- a/skills/insyra/SKILL.md
+++ b/skills/insyra/SKILL.md
@@ -171,6 +171,30 @@ Policies:
 - `LabelSortFirstSeen`, `LabelSortLexicographic`, `LabelSortByFrequency` control label ids.
 - Column refs resolve by name first, then Excel-style index (`A`, `B`, `AA`). Category identity keeps typed values distinct (`1` and `"1"` are different).
 
+### 1d) Scale numeric features (fit once, reuse)
+
+Feature scalers fit parameters on a training set and reuse them on a test set — the leakage-free alternative to the stateless, in-place `DataList.Normalize()` / `Standardize()`. Each method returns a new table plus a fitted scaler; the receiver is not modified.
+
+```go
+sc := insyra.NewStandardScaler() // or NewMinMaxScaler(0,1), NewRobustScaler(), NewMaxAbsScaler()
+trainScaled, err := sc.FitTransform(train, "Age", "Income")
+if err != nil { log.Fatal(err) }
+
+testScaled, err := sc.Transform(test)          // reuse TRAIN mean/std — no re-fit
+original, err := sc.InverseTransform(trainScaled) // back to original scale
+_ = trainScaled
+_ = testScaled
+_ = original
+
+params := sc.Params()["Age"] // {Mean, Std, ...} depending on kind
+_ = params
+```
+
+- Pick by data: `StandardScaler` (Gaussian-ish, matches `Standardize`'s sample std), `MinMaxScaler` (bounded range), `RobustScaler` (outliers; median/IQR), `MaxAbsScaler` (sparse/sign-preserving, `[-1,1]`).
+- `cols` is required; other columns pass through. Column order, names, table name, and row names are preserved.
+- `nil`/`NaN` are preserved and excluded from fitting. A non-numeric value in a target column is an error. `Transform` errors on a missing fitted column; constant/degenerate columns do not panic.
+- DataList versions exist too: `FitDataList`, `TransformDataList`, `FitTransformDataList`, `InverseTransformDataList`.
+
 ### 2) Read a CSV file into a DataTable + preview
 
 ```go

--- a/skills/use-insyra-cli/SKILL.md
+++ b/skills/use-insyra-cli/SKILL.md
@@ -174,6 +174,13 @@ insyra encode sales onehot region,channel dropfirst true as x
 insyra encode sales label segment newcol segment_id sortby freq keeporiginal true as labeled
 insyra encode survey ordinal satisfaction order low,medium,high unknown error as ranked
 
+# Stateful feature scaling: fit on train, reuse on test (no leakage)
+insyra split sales train 0.8 as train test
+insyra scale fit std sc train cols Age,Income
+insyra scale transform sc train as train_scaled
+insyra scale transform sc test as test_scaled
+insyra scale inverse sc train_scaled as train_original
+
 # SQL: connect, list tables, load query, transform, write back, disconnect
 # Connections live for the current process only — reopen at the top of every session/script.
 insyra db connect main sqlite:./demo.db
@@ -201,6 +208,12 @@ insyra regression poisson y x1 x2
 - `encode <var> onehot <col1[,col2,...]> [dropfirst true|false] [keeporiginal true|false] [nan category|error|skip] [unknown ignore|error|new] [prefix <p>] [sep <s>] [sortcats true|false] [as <var>]`
 - `encode <var> label <col> [newcol <name>] [sortby firstseen|lex|freq] [nan category|error|skip] [unknown ignore|error|new] [keeporiginal true|false] [as <var>]`
 - `encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]`
+
+`scale`, unlike `encode`, is **stateful**: `scale fit` stores a reusable scaler variable that `scale transform` / `scale inverse` apply, so you can fit on train and transform test with the same parameters. Scaler variables are session-only (not saved to a named environment). `minmax` defaults to `[0,1]` if `range` is omitted; `nil`/`NaN` are preserved and ignored when fitting; `show <scalerVar>` prints kind + fitted columns.
+
+- `scale fit std|minmax|robust|maxabs <scalerVar> <tableVar> [range <min> <max>] cols <c1,c2,...>`
+- `scale transform <scalerVar> <tableVar> as <outVar>`
+- `scale inverse <scalerVar> <tableVar> as <outVar>`
 
 ## Database (db) workflow notes
 

--- a/skills/use-insyra-cli/references/cli-command-guide.md
+++ b/skills/use-insyra-cli/references/cli-command-guide.md
@@ -305,6 +305,19 @@ Generated from current command registry (`insyra help`, `insyra help <command>`)
   - `encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]`
 - Notes: one-shot only; use Go encoders for reusable train/test `Transform`. `order` values are parsed as literals.
 
+### `scale`
+- Description: Fit a reusable feature scaler and transform/inverse tables with it (stateful)
+- Usage: `scale fit std|minmax|robust|maxabs <scalerVar> <tableVar> [range <min> <max>] cols <c1,c2,...>` / `scale transform|inverse <scalerVar> <tableVar> as <outVar>`
+- Examples: `insyra scale fit std sc train cols Age,Income` / `insyra scale transform sc test as test_scaled` / `insyra scale inverse sc pred as pred_original`
+- Full forms:
+  - `scale fit std <scalerVar> <tableVar> cols <c1,c2,...>`
+  - `scale fit minmax <scalerVar> <tableVar> range <min> <max> cols <c1,c2,...>` (range defaults to 0 1)
+  - `scale fit robust <scalerVar> <tableVar> cols <c1,c2,...>`
+  - `scale fit maxabs <scalerVar> <tableVar> cols <c1,c2,...>`
+  - `scale transform <scalerVar> <tableVar> as <outVar>`
+  - `scale inverse <scalerVar> <tableVar> as <outVar>`
+- Notes: stateful — fit on train, transform train and test with the same parameters (no leakage). Scaler variables are session-only. `nil`/`NaN` preserved and ignored when fitting; non-fitted columns pass through; `show <scalerVar>` prints kind + fitted columns.
+
 ### `ccl`
 - Description: Execute CCL statements on DataTable
 - Usage: `ccl <var> <expression>`

--- a/skills/use-insyra-cli/references/cli-command-usage.md
+++ b/skills/use-insyra-cli/references/cli-command-usage.md
@@ -181,6 +181,23 @@ This is separate from boolean-flag parsing used by option arguments like `header
   - `unknown`: `ignore`, `error`, `new` for onehot/label; `ignore`, `error` for ordinal CLI.
   - `order` values are comma-separated and parsed through the literal-value ladder.
 
+## `scale`
+- Description: Fit a reusable feature scaler and transform/inverse tables with it (stateful)
+- Usage: `scale fit std|minmax|robust|maxabs <scalerVar> <tableVar> [range <min> <max>] cols <c1,c2,...>` / `scale transform|inverse <scalerVar> <tableVar> as <outVar>`
+- Full forms:
+	- `scale fit std <scalerVar> <tableVar> cols <c1,c2,...>`
+	- `scale fit minmax <scalerVar> <tableVar> range <min> <max> cols <c1,c2,...>`
+	- `scale fit robust <scalerVar> <tableVar> cols <c1,c2,...>`
+	- `scale fit maxabs <scalerVar> <tableVar> cols <c1,c2,...>`
+	- `scale transform <scalerVar> <tableVar> as <outVar>`
+	- `scale inverse <scalerVar> <tableVar> as <outVar>`
+- Notes:
+  - Works on DataTable variables only.
+  - Stateful: `scale fit` stores a scaler variable; `transform`/`inverse` reuse it. Fit on train, transform test with the same parameters (no leakage).
+  - Scaler variables are session-only and not saved to a named environment.
+  - `minmax` defaults to `[0,1]` when `range` is omitted; `range` is only valid for `minmax`.
+  - `nil`/`NaN` are preserved and excluded from fitting; non-fitted columns pass through unchanged.
+
 ## `env`
 - Description: Environment management
 - Usage: `env <create|list|open|clear|export|import|delete|rename|info> [args]`

--- a/skills/use-insyra-cli/references/cli-commands.md
+++ b/skills/use-insyra-cli/references/cli-commands.md
@@ -82,6 +82,7 @@ This list is generated from `insyra help` in this repository state.
 - `pivot` - Reshape long-form DataTable to wide form (long -> wide)
 - `unpivot` - Reshape wide-form DataTable to long form (wide -> long)
 - `encode` - One-shot categorical encoding for DataTable variables
+- `scale` - Fit a reusable feature scaler and transform/inverse tables with it
 - `ccl` - Execute CCL statements on DataTable
 - `addcolccl` - Add DataTable column using CCL
 
@@ -171,3 +172,13 @@ This list is generated from `insyra help` in this repository state.
 - `encode <var> ordinal <col> order <v1,v2,...> [newcol <name>] [unknown error|ignore] [nan category|error|skip] [keeporiginal true|false] [as <var>]`
   - Uses the explicit order as `0..n-1`; `order` values are parsed as literals.
 - CLI encoding is one-shot fit+transform and does not persist encoder state. Use the Go API when you need reusable train/test `Transform`.
+
+## Feature Scaling Command
+
+- `scale fit std|minmax|robust|maxabs <scalerVar> <tableVar> [range <min> <max>] cols <c1,c2,...>`
+  - Fits a scaler on the listed columns of `<tableVar>` and stores it as `<scalerVar>`. `minmax` defaults to `[0,1]` when `range` is omitted; `range` is only valid for `minmax`.
+- `scale transform <scalerVar> <tableVar> as <outVar>`
+  - Applies the fitted scaler to `<tableVar>`, writing a new table to `<outVar>`.
+- `scale inverse <scalerVar> <tableVar> as <outVar>`
+  - Restores the original scale of fitted columns.
+- Unlike `encode`, `scale` is stateful: fit once, then transform train and test with the same parameters (no leakage). Scaler variables are session-only (not persisted to a named environment). `nil`/`NaN` are preserved and ignored when fitting; non-fitted columns pass through. `show <scalerVar>` prints the scaler kind and fitted columns.


### PR DESCRIPTION
Implements #170.

新增一組可 `Fit`、可重複 `Transform`、可 `InverseTransform` 的特徵縮放器，支援正式 ML preprocessing 流程：在訓練集 fit、用同一組參數轉換測試集，避免 data leakage。這是現有就地、無狀態的 `DataList.Normalize()` / `Standardize()` 所做不到的。

## 範圍
- 留在 root package，貼齊既有 categorical encoder 慣例（DataTable 方法回傳 fitted 物件 + `Transform`/`InverseTransform`/`Kind`）。**不開新包、不碰 `isr/`、不碰 CCL。**
- 四種 scaler：StandardScaler / MinMaxScaler / RobustScaler / MaxAbsScaler，皆有 DataTable 與 DataList 版本。

## 設計重點
- 四種 scaler 統一成 affine `y=(x-center)/scale*gain+offset`，退化情況（`std==0`/`max==min`/`IQR==0`/`maxAbs==0`）設 `scale=1`，不 panic。
- StandardScaler 用**樣本** std、RobustScaler 用 `Quartile` 法，刻意與庫內既有 `Standardize()` / `IQR()` 一致（而非 sklearn 母體 std）。
- `nil`/`NaN` 保留且不納入 fit；目標欄非數值 → error；`Transform` 缺 fitted 欄 → error。
- 欄序、欄名、表名、列名皆保留；原始資料不修改。

## CLI
新增 stateful `scale` 指令（`fit` / `transform` / `inverse`），可在 REPL 或 `.isr` 腳本中 fit-on-train、transform-on-test。Scaler 變數僅限 session（不持久化到 named environment）。

```
split dt train 0.8 as train test
scale fit std sc train cols Age,Income
scale transform sc train as train_scaled
scale transform sc test as test_scaled
scale inverse sc pred as pred_original
```

## 驗證
- `go build ./...`、`go vet ./...`、`go test ./...` 全通過。
- 新增 root 與 CLI 測試，涵蓋參數正確性、round-trip、常數欄、NaN/nil 保留、shape 保留、train-fit/test-transform 不重算、缺欄/未 fit/非數值報錯、DataList API。

## 文件
Docs/DataTable.md（Feature Scaling 段，含為何不等於 Normalize/Standardize、train/test 用法、選用表）、Docs/cli-dsl.md、skills/insyra、skills/use-insyra-cli（含 references）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)