### PR TITLE
feat(csv): ReadCSV option to disable type inference / load all cells as raw strings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,12 @@ Keep the English ([README.md](README.md), `Docs/`) and Traditional-Chinese ([REA
 
 Out-of-scope issues discovered during development, waiting for a decision. Delete an entry once it is resolved.
 
+### [2026-07-26] — ReadExcelSheet does no type inference (inconsistent with CSV)
+- **Where**: [read.go](read.go) `ReadExcelSheet` → `ReadSlice2D`
+- **What**: excelize `GetRows` returns strings and `ReadSlice2D` appends them as-is, so Excel loads produce all-string DataTables while CSV loads run column-level inference (`inferCSVColumnTypes`). Opposite defaults for the two spreadsheet formats. Noticed while adding `CSVReadOptions.RawStrings` (issue #188).
+- **Suggestion**: Decide whether Excel reads should run the same column inference by default (with the same opt-out), or stay raw; either way document the behavior in `Docs/DataTable.md`.
+- **Status**: pending
+
 ### [2026-07-11] — chromedp chain left at pre-refresh versions (two independent blockers)
 - **Where**: `go.mod` — `chromedp v0.11.2`, `cdproto v0.0.0-20241208230723-d1c7de7e5dd2` (pulled in via `go-echarts/snapshot-chromedp`)
 - **What**: The 2026-07-11 dependency refresh could not move these. (1) `chromedp v0.15.0+` and newer `cdproto` require go >= 1.26, while the module's `go` directive stays on 1.25.x (minimum-Go promise to downstream users). (2) The newest go1.25-compatible version, `chromedp v0.14.2`, hard-requires `go-json-experiment/json`, whose generic-variadic code panics govulncheck's symbol-level scan ("got jsontext.Value, want variadic parameter of unnamed slice or string type" in x/tools go/ssa — still broken as of x/tools v0.48.0 / x/vuln v1.6.0), which would permanently break the Govulncheck CI workflow.

--- a/Docs/DataTable.md
+++ b/Docs/DataTable.md
@@ -147,6 +147,38 @@ if err != nil {
 }
 ```
 
+### ReadCSV_FileWithOptions / ReadCSV_StringWithOptions
+
+```go
+type CSVReadOptions struct {
+    FirstColToRowNames bool
+    FirstRowToColNames bool
+    Encoding           string // file input only; "" or "auto" auto-detects
+    RawStrings         bool   // keep every cell as its original string; skip type inference
+}
+
+func ReadCSV_FileWithOptions(filePath string, opts CSVReadOptions) (*DataTable, error)
+func ReadCSV_StringWithOptions(csvString string, opts CSVReadOptions) (*DataTable, error)
+```
+
+**Description:** Options-based variants of `ReadCSV_File` / `ReadCSV_String`. The zero value of `CSVReadOptions` behaves exactly like the legacy functions with both flags `false`.
+
+Set `RawStrings: true` to disable column type inference entirely: every cell is kept as its original string and empty cells stay `""` (not `NaN`). Use this for data that looks numeric but must not be parsed as numbers — stock IDs (`0050` would otherwise become `int64` `50`, losing the leading zeros), tax IDs, phone numbers, zip codes, or exact monetary amounts you want to parse with a decimal type yourself.
+
+**Example:**
+
+```go
+csvData := "id,price\n0050,600.855\n00878,100.14"
+dt, err := insyra.ReadCSV_StringWithOptions(csvData, insyra.CSVReadOptions{
+    FirstRowToColNames: true,
+    RawStrings:         true,
+})
+if err != nil {
+    log.Fatal(err)
+}
+// dt cells are all strings: "0050", "00878", "600.855", ...
+```
+
 ### ReadJSON_File
 
 ```go

--- a/Docs/cli-dsl.md
+++ b/Docs/cli-dsl.md
@@ -309,6 +309,7 @@ insyra --env demo run pipeline.isr
 - `headers true|false` — whether the first row holds column names. Default `true`.
 - `rownames true|false` — whether the first column holds row names. Default `false`.
 - `encoding <enc>` — read-side hint for CSVs that aren't UTF-8 (e.g. `big5`, `gbk`). Auto-detected when omitted.
+- `infer true|false` — read-side, CSV only. `infer false` keeps every cell as its original string (no type inference): leading zeros in stock IDs survive, amounts stay verbatim, empty cells stay empty strings. Default `true`.
 - `bom true|false` — save-side, write a UTF-8 BOM (helps Windows Excel open Chinese CSVs). Default `false`.
 
 Boolean values accept `true|false`, `yes|no`, `on|off`, `1|0` (case-insensitive).
@@ -322,6 +323,9 @@ load gdp.csv rownames true as t
 
 # Big5 legacy CSV
 load legacy.csv encoding big5 as t
+
+# Stock IDs / exact amounts: load everything as raw strings
+load stocks.csv infer false as raw
 
 # Excel: 'sheet' is required; headers/rownames are optional
 load report.xlsx sheet 2025 rownames true as t
@@ -576,7 +580,7 @@ Source policy:
 | `knn_neighbors` | `knn_neighbors <train_var> <test_var> <k> [algorithm <auto\|brute\|kd_tree\|ball_tree>] [leafsize <n>] [as <var>]` | K-nearest neighbors search |
 | `kmeans` | `kmeans <var> <k> [nstart <n>] [itermax <n>] [seed <n>] [as <var>]` | K-means clustering |
 | `kurtosis` | `kurtosis <var>` | Kurtosis of a DataList |
-| `load` | `load <file> [headers true\|false] [rownames true\|false] [encoding <enc>] [sheet <name>] \| load parquet <file> [cols <c1,c2,...>] [rowgroups <i1,i2,...>] \| load sql <conn> <table> [where "..."] [order "..."] [limit N] [offset N] [cols "c1,c2"] [schema <s>] [indexcol <c>] [parsedates "c1,c2"] \| load sql <conn> query "<SQL>" [params <v1> <v2> ...] [as <var>]` | Load data into a DataTable variable from a file, parquet, or SQL connection |
+| `load` | `load <file> [headers true\|false] [rownames true\|false] [encoding <enc>] [infer true\|false] [sheet <name>] \| load parquet <file> [cols <c1,c2,...>] [rowgroups <i1,i2,...>] \| load sql <conn> <table> [where "..."] [order "..."] [limit N] [offset N] [cols "c1,c2"] [schema <s>] [indexcol <c>] [parsedates "c1,c2"] \| load sql <conn> query "<SQL>" [params <v1> <v2> ...] [as <var>]` | Load data into a DataTable variable from a file, parquet, or SQL connection |
 | `lower` | `lower <var> [as <var>]` | Lowercase DataList strings |
 | `max` | `max <var>` | DataList maximum |
 | `mean` | `mean <var>` | DataList mean |
@@ -602,7 +606,7 @@ Source policy:
 | `quartile` | `quartile <var> <q>` | DataList quartile |
 | `range` | `range <var>` | DataList range |
 | `rank` | `rank <var> [asc\|desc\|true\|false] [as <var>]` | Rank DataList |
-| `read` | `read <file> [headers true\|false] [rownames true\|false] [encoding <enc>] [sheet <name>]` | Quick preview a file without saving variable |
+| `read` | `read <file> [headers true\|false] [rownames true\|false] [encoding <enc>] [infer true\|false] [sheet <name>]` | Quick preview a file without saving variable |
 | `regression` | `regression <type> <y> <x...>` | Regression analysis: linear/poly/exp/log/logistic/poisson |
 | `rename` | `rename <var> <new>` | Rename variable |
 | `replace` | `replace <var> <old\|nan\|nil> <new>` | Replace values in DataTable/DataList |

--- a/Docs/isr.md
+++ b/Docs/isr.md
@@ -66,6 +66,7 @@ type CSV_inOpts struct {
     FirstCol2RowNames bool   // Treat the first column as row names
     FirstRow2ColNames bool   // Treat the first row as column names
     Encoding          string // Specify input file encoding (e.g., "big5", "utf-8"), Only for FilePath input
+    RawStrings        bool   // Keep every cell as its original string; skip column type inference
 }
 
 // Examples:

--- a/cli/commands/load.go
+++ b/cli/commands/load.go
@@ -13,17 +13,18 @@ import (
 func init() {
 	_ = Register(&CommandHandler{
 		Name:        "load",
-		Usage:       "load <file> [headers true|false] [rownames true|false] [encoding <enc>] [sheet <name>] | load parquet <file> [...] | load sql <conn> <table>|query \"<sql>\" [...] [as <var>]",
+		Usage:       "load <file> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [sheet <name>] | load parquet <file> [...] | load sql <conn> <table>|query \"<sql>\" [...] [as <var>]",
 		Description: "Load data into a DataTable variable from a file, parquet, or SQL connection",
 		Forms: []string{
-			"load <file.csv> [headers true|false] [rownames true|false] [encoding <enc>] [as <var>]",
+			"load <file.csv> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [as <var>]",
 			"load <file.json> [as <var>]",
 			"load <file.xlsx> sheet <name> [headers true|false] [rownames true|false] [as <var>]",
 			"load parquet <file> [cols <c1,c2,...>] [rowgroups <i1,i2,...>] [as <var>]",
 			"load sql <conn> <table> [where \"...\"] [order \"...\"] [limit N] [offset N] [cols \"c1,c2\"] [schema <s>] [indexcol <c>] [parsedates \"c1,c2\"] [as <var>]",
 			"load sql <conn> query \"<SQL>\" [params <v1> <v2> ...] [as <var>]",
 			"",
-			"File option defaults: headers=true, rownames=false.",
+			"File option defaults: headers=true, rownames=false, infer=true.",
+			"infer false (CSV only) keeps every cell as its original string — no type inference.",
 			"Booleans accept true|false|yes|no|on|off|1|0.",
 		},
 		Examples: []string{
@@ -31,6 +32,7 @@ func init() {
 			"insyra load matrix.csv headers false as raw",
 			"insyra load gdp.csv rownames true as gdp",
 			"insyra load legacy.csv encoding big5 as legacy",
+			"insyra load stocks.csv infer false as raw",
 			"insyra load report.xlsx sheet 2025 rownames true as r",
 			"insyra load parquet data.parquet cols id,amount rowgroups 0,1 as p",
 			"insyra load sql main customers as customers",
@@ -43,7 +45,7 @@ func init() {
 func runLoadCommand(ctx *ExecContext, args []string) error {
 	coreArgs, alias := parseAlias(args)
 	if len(coreArgs) == 0 {
-		return fmt.Errorf("usage: load <file> [headers true|false] [rownames true|false] [encoding <enc>] [sheet <name>] | load parquet <file> [...] | load sql <conn> <table>|query \"<sql>\" [...] [as <var>]")
+		return fmt.Errorf("usage: load <file> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [sheet <name>] | load parquet <file> [...] | load sql <conn> <table>|query \"<sql>\" [...] [as <var>]")
 	}
 
 	var table *insyra.DataTable
@@ -78,19 +80,23 @@ func runLoadCommand(ctx *ExecContext, args []string) error {
 			if opts.SheetSet {
 				return fmt.Errorf("load csv: 'sheet' is not valid for CSV files")
 			}
-			if opts.Encoding != "" {
-				table, err = insyra.ReadCSV_File(path, opts.RowNames, opts.Headers, opts.Encoding)
-			} else {
-				table, err = insyra.ReadCSV_File(path, opts.RowNames, opts.Headers)
-			}
+			table, err = insyra.ReadCSV_FileWithOptions(path, insyra.CSVReadOptions{
+				FirstColToRowNames: opts.RowNames,
+				FirstRowToColNames: opts.Headers,
+				Encoding:           opts.Encoding,
+				RawStrings:         !opts.Infer,
+			})
 		case "json":
-			if opts.HeadersSet || opts.RowNamesSet || opts.SheetSet || opts.Encoding != "" {
-				return fmt.Errorf("load json: headers/rownames/sheet/encoding options are not supported for JSON")
+			if opts.HeadersSet || opts.RowNamesSet || opts.SheetSet || opts.Encoding != "" || opts.InferSet {
+				return fmt.Errorf("load json: headers/rownames/sheet/encoding/infer options are not supported for JSON")
 			}
 			table, err = insyra.ReadJSON_File(path)
 		case "excel":
 			if opts.Encoding != "" {
 				return fmt.Errorf("load excel: 'encoding' is not valid for Excel files")
+			}
+			if opts.InferSet {
+				return fmt.Errorf("load excel: 'infer' is not valid for Excel files")
 			}
 			if !opts.SheetSet || opts.Sheet == "" {
 				return fmt.Errorf("usage for excel: load <file.xlsx> sheet <sheet-name> [headers true|false] [rownames true|false] [as <var>]")
@@ -119,10 +125,12 @@ type fileLoadOptions struct {
 	Encoding    string
 	Sheet       string
 	SheetSet    bool
+	Infer       bool
+	InferSet    bool
 }
 
 func parseFileLoadOptions(args []string) (fileLoadOptions, error) {
-	opts := fileLoadOptions{Headers: true, RowNames: false}
+	opts := fileLoadOptions{Headers: true, RowNames: false, Infer: true}
 	for i := 0; i < len(args); {
 		key := strings.ToLower(args[i])
 		next := func() (string, error) {
@@ -171,8 +179,20 @@ func parseFileLoadOptions(args []string) (fileLoadOptions, error) {
 			opts.Sheet = v
 			opts.SheetSet = true
 			i += 2
+		case "infer":
+			v, err := next()
+			if err != nil {
+				return opts, err
+			}
+			b, err := parseFlexBool(v)
+			if err != nil {
+				return opts, fmt.Errorf("load: invalid value for infer: %w", err)
+			}
+			opts.Infer = b
+			opts.InferSet = true
+			i += 2
 		default:
-			return opts, fmt.Errorf("load: unknown option %q (supported: headers, rownames, encoding, sheet)", args[i])
+			return opts, fmt.Errorf("load: unknown option %q (supported: headers, rownames, encoding, sheet, infer)", args[i])
 		}
 	}
 	return opts, nil

--- a/cli/commands/load_save_test.go
+++ b/cli/commands/load_save_test.go
@@ -75,6 +75,43 @@ func TestLoad_CSV_RejectsSheetOption(t *testing.T) {
 	}
 }
 
+func TestLoad_CSV_InferFalseKeepsRawStrings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "in.csv")
+	mustWrite(t, path, "id,price\n0050,600.855\n00878,\n")
+
+	ctx := newTestExecContext(t)
+	if err := runLoadCommand(ctx, []string{path, "infer", "false", "as", "t"}); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	dt, _ := getDataTableVar(ctx, "t")
+	if got := dt.GetColByName("id").Data()[0]; got != "0050" {
+		t.Fatalf("expected raw string \"0050\", got %v (%T)", got, got)
+	}
+	if got := dt.GetColByName("price").Data()[1]; got != "" {
+		t.Fatalf("expected empty cell to stay \"\", got %v (%T)", got, got)
+	}
+}
+
+func TestLoad_JSON_RejectsInferOption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "in.json")
+	mustWrite(t, path, `[{"a":1}]`)
+	ctx := newTestExecContext(t)
+	err := runLoadCommand(ctx, []string{path, "infer", "false", "as", "t"})
+	if err == nil || !strings.Contains(err.Error(), "infer") {
+		t.Fatalf("expected error rejecting 'infer' for JSON, got %v", err)
+	}
+}
+
+func TestLoad_Excel_RejectsInferOption(t *testing.T) {
+	ctx := newTestExecContext(t)
+	err := runLoadCommand(ctx, []string{"in.xlsx", "sheet", "S1", "infer", "false", "as", "t"})
+	if err == nil || !strings.Contains(err.Error(), "infer") {
+		t.Fatalf("expected error rejecting 'infer' for Excel, got %v", err)
+	}
+}
+
 func TestLoad_RejectsUnknownOption(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "in.csv")

--- a/cli/commands/read.go
+++ b/cli/commands/read.go
@@ -5,7 +5,7 @@ import "fmt"
 func init() {
 	_ = Register(&CommandHandler{
 		Name:        "read",
-		Usage:       "read <file> [headers true|false] [rownames true|false] [encoding <enc>] [sheet <name>]",
+		Usage:       "read <file> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [sheet <name>]",
 		Description: "Quick preview a file without saving variable",
 		Run:         runReadCommand,
 	})
@@ -13,7 +13,7 @@ func init() {
 
 func runReadCommand(ctx *ExecContext, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: read <file> [headers true|false] [rownames true|false] [encoding <enc>] [sheet <name>]")
+		return fmt.Errorf("usage: read <file> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [sheet <name>]")
 	}
 	fakeArgs := append([]string(nil), args...)
 	fakeArgs = append(fakeArgs, "as", "$preview")

--- a/isr/csv.go
+++ b/isr/csv.go
@@ -11,6 +11,7 @@ type CSV_inOpts struct {
 	FirstCol2RowNames bool
 	FirstRow2ColNames bool
 	Encoding          string // optional, default is "auto", only for FilePath input
+	RawStrings        bool   // keep every cell as its original string; skip column type inference
 }
 
 type CSV_outOpts struct {

--- a/isr/dt.go
+++ b/isr/dt.go
@@ -114,14 +114,16 @@ func (d dt) From(item any) *dt {
 	case CSV:
 		t.DataTable = insyra.NewDataTable()
 		var err error
+		opts := insyra.CSVReadOptions{
+			FirstColToRowNames: val.InputOpts.FirstCol2RowNames,
+			FirstRowToColNames: val.InputOpts.FirstRow2ColNames,
+			Encoding:           val.InputOpts.Encoding,
+			RawStrings:         val.InputOpts.RawStrings,
+		}
 		if val.FilePath != "" {
-			var encoding = val.InputOpts.Encoding
-			if encoding == "" {
-				encoding = "auto"
-			}
-			t.DataTable, err = insyra.ReadCSV_File(val.FilePath, val.InputOpts.FirstCol2RowNames, val.InputOpts.FirstRow2ColNames, encoding)
+			t.DataTable, err = insyra.ReadCSV_FileWithOptions(val.FilePath, opts)
 		} else {
-			t.DataTable, err = insyra.ReadCSV_String(val.String, val.InputOpts.FirstCol2RowNames, val.InputOpts.FirstRow2ColNames)
+			t.DataTable, err = insyra.ReadCSV_StringWithOptions(val.String, opts)
 		}
 		if err != nil {
 			insyra.LogFatal("DT", "From", "%v", err)

--- a/openspec/changes/csv-raw-read-option/.openspec.yaml
+++ b/openspec/changes/csv-raw-read-option/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/csv-raw-read-option/design.md
+++ b/openspec/changes/csv-raw-read-option/design.md
@@ -1,0 +1,34 @@
+# Design: csv-raw-read-option
+
+## Context
+
+CSV 讀取邏輯集中在 `read.go`:`ReadCSV_File`(含編碼偵測)與 `ReadCSV_String` 各自實作「parse rows → 建欄 → 填資料」後呼叫 `inferCSVColumnTypes(dt)`。兩函數本體高度重複。`ReadCSV_File` 尾端已有 `encoding ...string` 可變參數,無法再無痛追加參數。isr 層以 `CSV_inOpts` struct 包裝,CLI `load` 以 `parseFileLoadOptions` 解析 key-value 選項。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提供關閉型別推斷的 CSV 讀法,cell 保留原始字串。
+- 既有 API 簽名與行為零變動。
+- 選項集中於可擴充的 struct,未來加選項不再新增函數。
+
+**Non-Goals:**
+- Per-column 型別指定(如 `StringCols`)— 等有真實需求再擴充。
+- Excel/JSON 讀取行為調整(`ReadExcelSheet` 本來就不推斷,見 Follow-ups)。
+- decimal 型別支援 — 由呼叫端自行解析。
+
+## Decisions
+
+1. **Options struct + 新函數對,而非 `_Raw` 函數對或改簽名**:`ReadCSV_FileWithOptions` / `ReadCSV_StringWithOptions` 接 `CSVReadOptions`。與 `parquet.Read(ctx, path, opt)` 風格一致;`_Raw` 對會讓 API 隨選項數翻倍;改簽名是 breaking change。
+2. **零值即現行為**:欄位取名 `RawStrings`(而非 `InferTypes`),使 `CSVReadOptions{}` 的零值對應「照舊推斷」,舊函數可直接委派。
+3. **消重**:抽出私有函數 `csvRowsToDataTable(rows [][]string, opts CSVReadOptions) *DataTable` 承載共用的建欄/填資料/推斷邏輯;File 版只多編碼偵測,String 版只多 BOM 剝除。不新增其他抽象。
+4. **空 cell 語意**:raw 模式空 cell 保留 `""`。呼叫端自行辨識空值,符合 issue 期望(不再是 NaN)。
+5. **CLI 選項名用 `infer`**:與「type inference」概念直接對應,布林形式與既有 `headers`/`rownames` 一致;非 CSV 格式帶 `infer` 回錯誤,比照 `sheet`/`encoding` 的既有檢查模式。
+
+## Risks / Trade-offs
+
+- [root API 出現第三種讀法] → 文件明確標示 WithOptions 為建議入口,舊函數說明指向新函數;不 deprecate,避免 churn。
+- [重構共用邏輯可能改變既有行為] → 以既有測試 + 新增「零值 options 與舊函數輸出一致」測試把關。
+
+## Open Questions
+
+無 — API 形狀已與維護者確認(options struct)。

--- a/openspec/changes/csv-raw-read-option/proposal.md
+++ b/openspec/changes/csv-raw-read-option/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: csv-raw-read-option
+
+## Why
+
+`ReadCSV_File` / `ReadCSV_String` always run column-level type inference, which is destructive for "looks numeric but isn't" data: Taiwan stock IDs lose leading zeros irreversibly (`0050` → int64 `50`), exact monetary amounts are coerced to float64, and empty cells become NaN ([issue #188](https://github.com/HazelnutParadise/insyra/issues/188)). Callers who need exact values (stock IDs, tax IDs, phone numbers, decimal amounts) currently cannot use Insyra's CSV loading at all.
+
+## What Changes
+
+- Add `CSVReadOptions` struct (row/col name flags, encoding, `RawStrings bool`) to the root package.
+- Add `ReadCSV_FileWithOptions` / `ReadCSV_StringWithOptions`; when `RawStrings` is true every cell stays its original string (empty cell stays `""`), and type inference is skipped entirely.
+- Existing `ReadCSV_File` / `ReadCSV_String` keep their exact signatures and behavior, becoming thin wrappers over the new functions.
+- `isr`: `CSV_inOpts` gains a `RawStrings` field, passed through by `DT.From`.
+- CLI: `load <file.csv> infer true|false` option (default `true`); rejected for JSON/Excel.
+- Docs (`Docs/DataTable.md`, `Docs/cli-dsl.md`) and skills (`skills/insyra`, `skills/use-insyra-cli`) updated in the same change.
+
+## Capabilities
+
+### New Capabilities
+- `csv-read-options`: Options-based CSV loading API in the root package, including the raw-strings (no type inference) mode.
+
+### Modified Capabilities
+- `dsl-commands`: `load` command gains an `infer true|false` option for CSV files; non-CSV formats reject it.
+
+## Impact
+
+- `read.go` (new options struct + functions; existing functions delegate), `read_test.go`
+- `isr/csv.go`, `isr/dt.go`
+- `cli/commands/load.go` and its tests
+- `Docs/DataTable.md`, `Docs/cli-dsl.md`, `skills/insyra/SKILL.md`, `skills/use-insyra-cli/SKILL.md`
+- No breaking changes; no new dependencies.

--- a/openspec/changes/csv-raw-read-option/specs/csv-read-options/spec.md
+++ b/openspec/changes/csv-raw-read-option/specs/csv-read-options/spec.md
@@ -1,0 +1,43 @@
+# csv-read-options Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Options-based CSV loading API
+根套件 SHALL 提供 `CSVReadOptions` 結構與 `ReadCSV_FileWithOptions(filePath string, opts CSVReadOptions)`、`ReadCSV_StringWithOptions(csvString string, opts CSVReadOptions)` 兩個函數。`CSVReadOptions` SHALL 包含 `FirstColToRowNames bool`、`FirstRowToColNames bool`、`Encoding string`(僅檔案輸入有效,空字串或 `"auto"` 表示自動偵測)與 `RawStrings bool`。零值 options SHALL 產生與現有 `ReadCSV_File(path, false, false)` / `ReadCSV_String(s, false, false)` 完全相同的結果。
+
+#### Scenario: Zero-value options match legacy behavior
+- **WHEN** 呼叫 `ReadCSV_StringWithOptions(csv, CSVReadOptions{})`
+- **THEN** 結果與 `ReadCSV_String(csv, false, false)` 相同,欄位型別推斷照常執行
+
+#### Scenario: Row/col name flags map to legacy parameters
+- **WHEN** 呼叫 `ReadCSV_FileWithOptions(path, CSVReadOptions{FirstColToRowNames: true, FirstRowToColNames: true})`
+- **THEN** 結果與 `ReadCSV_File(path, true, true)` 相同
+
+### Requirement: Raw-strings mode disables type inference
+當 `CSVReadOptions.RawStrings` 為 true 時,系統 SHALL 將每個 cell 保留為 CSV 解析後的原始字串,SHALL NOT 執行任何欄位型別推斷或數值轉換。
+
+#### Scenario: Leading zeros preserved
+- **WHEN** 以 `RawStrings: true` 載入含股票代號欄 `2330`、`0050`、`00878` 的 CSV
+- **THEN** 三個 cell 皆為字串,`0050` 與 `00878` 的開頭零完整保留
+
+#### Scenario: Exact amounts stay strings
+- **WHEN** 以 `RawStrings: true` 載入含金額 `600.855` 與千分位 `"2,000"` 的 CSV
+- **THEN** cell 值為字串 `"600.855"` 與 `"2,000"`,不轉為 float64
+
+#### Scenario: Empty cell stays empty string
+- **WHEN** 以 `RawStrings: true` 載入含空 cell 的 CSV
+- **THEN** 該 cell 為空字串 `""`,不轉為 NaN 或 nil
+
+### Requirement: Legacy CSV functions remain unchanged
+`ReadCSV_File` 與 `ReadCSV_String` 的簽名與行為 SHALL 維持不變,並委派給 options 版本實作。
+
+#### Scenario: Legacy inference still applies
+- **WHEN** 呼叫 `ReadCSV_String(csv, false, true)` 載入全整數欄
+- **THEN** 該欄仍推斷為 int64(與既有行為一致)
+
+### Requirement: isr CSV input supports raw strings
+`isr` 套件的 `CSV_inOpts` SHALL 提供 `RawStrings bool` 欄位,`DT.From(CSV{...})` SHALL 將其傳遞至 options 版讀取函數。
+
+#### Scenario: isr passes RawStrings through
+- **WHEN** 呼叫 `DT.From(CSV{String: csv, InputOpts: CSV_inOpts{FirstRow2ColNames: true, RawStrings: true}})`
+- **THEN** 產生的 DataTable 所有 cell 皆為原始字串

--- a/openspec/changes/csv-raw-read-option/specs/dsl-commands/spec.md
+++ b/openspec/changes/csv-raw-read-option/specs/dsl-commands/spec.md
@@ -1,0 +1,18 @@
+# dsl-commands Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Load CSV without type inference
+`load` 命令 SHALL 支援 CSV 專用選項 `infer true|false`(預設 `true`)。`infer false` 時系統 SHALL 以 raw-strings 模式載入,所有 cell 保留原始字串。非 CSV 格式帶 `infer` 選項時 SHALL 回傳錯誤。布林值解析 SHALL 沿用既有規則(`true|false|yes|no|on|off|1|0`)。
+
+#### Scenario: Load CSV with inference disabled
+- **WHEN** 使用者執行 `load "stocks.csv" infer false as t`
+- **THEN** 系統以 raw-strings 模式載入,股票代號 `0050` 保留為字串
+
+#### Scenario: Default keeps inference on
+- **WHEN** 使用者執行 `load "data.csv" as t`(未帶 `infer`)
+- **THEN** 系統照常執行欄位型別推斷
+
+#### Scenario: infer rejected for non-CSV
+- **WHEN** 使用者執行 `load "data.json" infer false` 或 `load "data.xlsx" sheet S infer false`
+- **THEN** 系統回傳選項不適用的錯誤

--- a/openspec/changes/csv-raw-read-option/tasks.md
+++ b/openspec/changes/csv-raw-read-option/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: csv-raw-read-option
+
+## 1. Root package (read.go)
+
+- [x] 1.1 新增 `CSVReadOptions` struct 與私有 `csvRowsToDataTable` 共用邏輯(建欄、填資料、依 `RawStrings` 決定是否呼叫 `inferCSVColumnTypes`)
+- [x] 1.2 新增 `ReadCSV_FileWithOptions` / `ReadCSV_StringWithOptions`,舊 `ReadCSV_File` / `ReadCSV_String` 改為薄包裝
+- [x] 1.3 `read_test.go` 新增測試:raw 模式保留 `0050`/`00878` 開頭零、`"2,000"` 原樣、空 cell 為 `""`;零值 options 與舊函數輸出一致
+
+## 2. isr
+
+- [x] 2.1 `isr/csv.go` 的 `CSV_inOpts` 加 `RawStrings bool`;`isr/dt.go` 改呼叫 WithOptions 版本
+- [x] 2.2 isr 測試:`DT.From(CSV{InputOpts: {RawStrings: true}})` 全字串
+
+## 3. CLI
+
+- [x] 3.1 `cli/commands/load.go`:`fileLoadOptions` 加 `Infer`/`InferSet`,解析 `infer true|false`,非 CSV 帶 `infer` 回錯誤,更新 Usage/Forms/Examples
+- [x] 3.2 CLI 測試:`load x.csv infer false` 全字串、非 CSV 帶 `infer` 報錯
+
+## 4. Docs & skills
+
+- [x] 4.1 `Docs/DataTable.md`:新增 `CSVReadOptions` 與兩個 WithOptions 函數說明(含使用時機)
+- [x] 4.2 `Docs/cli-dsl.md`:`load` 選項與範例加 `infer`
+- [x] 4.3 `skills/insyra/SKILL.md`:讀 CSV 範例補 RawStrings 用法
+- [x] 4.4 `skills/use-insyra-cli/SKILL.md`:load 範例加 `infer false`
+- [x] 4.5 AGENTS.md `## Follow-ups` 記錄 `ReadExcelSheet` 不做型別推斷的既有不一致
+
+## 5. Verification
+
+- [x] 5.1 `go test ./...` 全綠、`golangci-lint run` 無新錯誤
+- [x] 5.2 REPL 手動驗證 `load x.csv infer false`

--- a/read.go
+++ b/read.go
@@ -86,22 +86,45 @@ func Slice2DToDataTable(data any) (*DataTable, error) {
 
 // ----- csv -----
 
+// CSVReadOptions configures ReadCSV_FileWithOptions and ReadCSV_StringWithOptions.
+// The zero value reproduces the default behavior of ReadCSV_File/ReadCSV_String:
+// no row/column names taken from the data, auto-detected encoding, and
+// column-level type inference enabled.
+type CSVReadOptions struct {
+	FirstColToRowNames bool
+	FirstRowToColNames bool
+	// Encoding applies to file input only; "" or "auto" auto-detects.
+	Encoding string
+	// RawStrings keeps every cell as its original string and skips column
+	// type inference entirely. Use it for data that looks numeric but must
+	// not be parsed as numbers (stock IDs like "0050", tax IDs, phone
+	// numbers, exact monetary amounts). Empty cells stay "".
+	RawStrings bool
+}
+
 // ReadCSV_File loads a CSV file into a DataTable, with options to set the first column as row names
 // and the first row as column names.
 func ReadCSV_File(filePath string, setFirstColToRowNames bool, setFirstRowToColNames bool, encoding ...string) (*DataTable, error) {
-	dt := NewDataTable()
+	opts := CSVReadOptions{
+		FirstColToRowNames: setFirstColToRowNames,
+		FirstRowToColNames: setFirstRowToColNames,
+	}
+	if len(encoding) > 0 {
+		opts.Encoding = encoding[0]
+	}
+	return ReadCSV_FileWithOptions(filePath, opts)
+}
 
+// ReadCSV_FileWithOptions loads a CSV file into a DataTable according to opts.
+func ReadCSV_FileWithOptions(filePath string, opts CSVReadOptions) (*DataTable, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = file.Close() }()
 
-	if len(encoding) == 0 {
-		encoding = []string{"auto"}
-	}
-	useEncoding := strings.ToLower(encoding[0])
-	if useEncoding == "auto" {
+	useEncoding := strings.ToLower(opts.Encoding)
+	if useEncoding == "" || useEncoding == "auto" {
 		detected, err := DetectEncoding(filePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to auto-detect encoding for %s: %v", filePath, err)
@@ -122,18 +145,25 @@ func ReadCSV_File(filePath string, setFirstColToRowNames bool, setFirstRowToColN
 		return nil, err
 	}
 
+	return csvRowsToDataTable(rows, opts), nil
+}
+
+// csvRowsToDataTable builds a DataTable from parsed CSV rows, applying the
+// row/column-name options and (unless opts.RawStrings) column type inference.
+func csvRowsToDataTable(rows [][]string, opts CSVReadOptions) *DataTable {
+	dt := NewDataTable()
 	dt.columns = []*DataList{}
 	dt.rowNames = core.NewBiIndex(0)
 
 	if len(rows) == 0 {
-		return dt, nil // 空的CSV
+		return dt // 空的CSV
 	}
 
 	// 處理第一行是否為欄名
 	startRow := 0
-	if setFirstRowToColNames {
+	if opts.FirstRowToColNames {
 		for i, colName := range rows[0] {
-			if setFirstColToRowNames && i == 0 {
+			if opts.FirstColToRowNames && i == 0 {
 				// 第一欄是行名，不作為列名處理
 				continue
 			}
@@ -144,7 +174,7 @@ func ReadCSV_File(filePath string, setFirstColToRowNames bool, setFirstRowToColN
 	} else {
 		// 如果沒有指定第一行作為列名，則動態生成列名
 		for i := range rows[0] {
-			if setFirstColToRowNames && i == 0 {
+			if opts.FirstColToRowNames && i == 0 {
 				continue
 			}
 			column := &DataList{}
@@ -154,7 +184,7 @@ func ReadCSV_File(filePath string, setFirstColToRowNames bool, setFirstRowToColN
 
 	// 處理資料行和是否將第一欄作為行名
 	for rowIndex, row := range rows[startRow:] {
-		if setFirstColToRowNames {
+		if opts.FirstColToRowNames {
 			rowName := row[0]
 			_, _ = dt.rowNames.Set(rowIndex, safeRowName(dt, rowName))
 			row = row[1:] // 移除第一欄作為行名
@@ -169,8 +199,10 @@ func ReadCSV_File(filePath string, setFirstColToRowNames bool, setFirstRowToColN
 		}
 	}
 
-	inferCSVColumnTypes(dt)
-	return dt, nil
+	if !opts.RawStrings {
+		inferCSVColumnTypes(dt)
+	}
+	return dt
 }
 
 // inferCSVColumnTypes converts each column's raw string cells to a homogeneous
@@ -227,8 +259,15 @@ func inferCSVColumnTypes(dt *DataTable) {
 }
 
 func ReadCSV_String(csvString string, setFirstColToRowNames bool, setFirstRowToColNames bool) (*DataTable, error) {
-	dt := NewDataTable()
+	return ReadCSV_StringWithOptions(csvString, CSVReadOptions{
+		FirstColToRowNames: setFirstColToRowNames,
+		FirstRowToColNames: setFirstRowToColNames,
+	})
+}
 
+// ReadCSV_StringWithOptions loads a CSV string into a DataTable according to opts.
+// opts.Encoding is ignored: the input is already a Go string.
+func ReadCSV_StringWithOptions(csvString string, opts CSVReadOptions) (*DataTable, error) {
 	// Strip a leading UTF-8 BOM so the first header/cell is not corrupted
 	// (consistent with the file reader).
 	csvString = strings.TrimPrefix(csvString, string([]byte{0xEF, 0xBB, 0xBF}))
@@ -239,52 +278,7 @@ func ReadCSV_String(csvString string, setFirstColToRowNames bool, setFirstRowToC
 		return nil, err
 	}
 
-	dt.columns = []*DataList{}
-	dt.rowNames = core.NewBiIndex(0)
-
-	if len(rows) == 0 {
-		return dt, nil // 空的CSV
-	}
-
-	// 處理第一行是否為欄名
-	startRow := 0
-	if setFirstRowToColNames {
-		for i, colName := range rows[0] {
-			if setFirstColToRowNames && i == 0 {
-				continue
-			}
-			column := &DataList{name: safeColName(dt, colName)}
-			dt.columns = append(dt.columns, column)
-		}
-		startRow = 1
-	} else {
-		for i := range rows[0] {
-			if setFirstColToRowNames && i == 0 {
-				continue
-			}
-			column := &DataList{}
-			dt.columns = append(dt.columns, column)
-		}
-	}
-
-	for rowIndex, row := range rows[startRow:] {
-		if setFirstColToRowNames {
-			rowName := row[0]
-			_, _ = dt.rowNames.Set(rowIndex, safeRowName(dt, rowName))
-			row = row[1:] // 移除第一欄作為行名
-		}
-
-		for colIndex, cell := range row {
-			if colIndex >= len(dt.columns) {
-				continue
-			}
-			column := dt.columns[colIndex]
-			column.data = append(column.data, cell)
-		}
-	}
-
-	inferCSVColumnTypes(dt)
-	return dt, nil
+	return csvRowsToDataTable(rows, opts), nil
 }
 
 // ----- excel -----

--- a/read_test.go
+++ b/read_test.go
@@ -1,6 +1,7 @@
 package insyra_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/HazelnutParadise/insyra"
@@ -270,5 +271,107 @@ func TestReadJSON(t *testing.T) {
 	if dtt.GetColByName("city").Data()[0] != "NYC" {
 		t.Errorf("ReadJSON() did not parse the correct data, expected 'NYC', got '%s'", dtt.GetColByName("city").Data()[0])
 		return
+	}
+}
+
+// Issue #188: RawStrings mode loads every cell as its original string —
+// leading zeros in stock IDs survive, thousand-separated amounts stay verbatim,
+// and empty cells stay "" instead of becoming NaN.
+func TestReadCSV_StringWithOptions_RawStrings(t *testing.T) {
+	csvData := "股票代號,集保庫存,成交均價\n2330,1000,600.855\n0050,\"2,000\",100.14\n00878,1500,\n"
+	dt, err := insyra.ReadCSV_StringWithOptions(csvData, insyra.CSVReadOptions{
+		FirstRowToColNames: true,
+		RawStrings:         true,
+	})
+	if err != nil {
+		t.Fatalf("ReadCSV_StringWithOptions: %v", err)
+	}
+
+	ids := dt.GetColByName("股票代號").Data()
+	wantIDs := []any{"2330", "0050", "00878"}
+	for i, want := range wantIDs {
+		if ids[i] != want {
+			t.Errorf("stock ID row %d: expected %q, got %v (%T)", i, want, ids[i], ids[i])
+		}
+	}
+
+	inventory := dt.GetColByName("集保庫存").Data()
+	if inventory[1] != "2,000" {
+		t.Errorf("inventory row 1: expected \"2,000\", got %v (%T)", inventory[1], inventory[1])
+	}
+
+	prices := dt.GetColByName("成交均價").Data()
+	if prices[0] != "600.855" {
+		t.Errorf("price row 0: expected \"600.855\", got %v (%T)", prices[0], prices[0])
+	}
+	if prices[2] != "" {
+		t.Errorf("price row 2 (empty cell): expected \"\", got %v (%T)", prices[2], prices[2])
+	}
+}
+
+// Zero-value CSVReadOptions must reproduce the legacy functions exactly,
+// including column type inference.
+func TestReadCSV_WithOptions_ZeroValueMatchesLegacy(t *testing.T) {
+	csvData := "id,val,note\n0050,600.855,a\n2330,100.14,b\n"
+	legacy, err := insyra.ReadCSV_String(csvData, false, true)
+	if err != nil {
+		t.Fatalf("ReadCSV_String: %v", err)
+	}
+	withOpts, err := insyra.ReadCSV_StringWithOptions(csvData, insyra.CSVReadOptions{FirstRowToColNames: true})
+	if err != nil {
+		t.Fatalf("ReadCSV_StringWithOptions: %v", err)
+	}
+
+	for _, col := range []string{"id", "val", "note"} {
+		l, w := legacy.GetColByName(col).Data(), withOpts.GetColByName(col).Data()
+		if len(l) != len(w) {
+			t.Fatalf("column %s: length mismatch %d vs %d", col, len(l), len(w))
+		}
+		for i := range l {
+			if l[i] != w[i] {
+				t.Errorf("column %s row %d: legacy %v (%T) vs options %v (%T)", col, i, l[i], l[i], w[i], w[i])
+			}
+		}
+	}
+	// Inference still applies with zero-value options: the id column is all-int.
+	if withOpts.GetColByName("id").Data()[0] != int64(50) {
+		t.Errorf("expected inferred int64(50), got %v (%T)", withOpts.GetColByName("id").Data()[0], withOpts.GetColByName("id").Data()[0])
+	}
+}
+
+func TestReadCSV_FileWithOptions_RawStrings(t *testing.T) {
+	path := t.TempDir() + "/stocks.csv"
+	if err := os.WriteFile(path, []byte("id,qty\n0050,1000\n00878,\n"), 0o644); err != nil {
+		t.Fatalf("write temp csv: %v", err)
+	}
+	dt, err := insyra.ReadCSV_FileWithOptions(path, insyra.CSVReadOptions{
+		FirstRowToColNames: true,
+		RawStrings:         true,
+	})
+	if err != nil {
+		t.Fatalf("ReadCSV_FileWithOptions: %v", err)
+	}
+	if got := dt.GetColByName("id").Data()[0]; got != "0050" {
+		t.Errorf("expected \"0050\", got %v (%T)", got, got)
+	}
+	if got := dt.GetColByName("qty").Data()[1]; got != "" {
+		t.Errorf("empty cell: expected \"\", got %v (%T)", got, got)
+	}
+}
+
+// isr passes CSV_inOpts.RawStrings through to the options-based reader.
+func TestReadCSV_ISR_RawStrings(t *testing.T) {
+	dtt := isr.DT.From(isr.CSV{
+		String: "id,price\n0050,100.14\n",
+		InputOpts: isr.CSV_inOpts{
+			FirstRow2ColNames: true,
+			RawStrings:        true,
+		},
+	})
+	if got := dtt.GetColByName("id").Data()[0]; got != "0050" {
+		t.Errorf("expected \"0050\", got %v (%T)", got, got)
+	}
+	if got := dtt.GetColByName("price").Data()[0]; got != "100.14" {
+		t.Errorf("expected \"100.14\", got %v (%T)", got, got)
 	}
 }

--- a/skills/insyra/SKILL.md
+++ b/skills/insyra/SKILL.md
@@ -215,6 +215,18 @@ func main() {
         log.Fatal(err)
     }
 
+    // RawStrings disables inference entirely — every cell stays its original
+    // string (empty cells stay ""). Use for stock IDs ("0050" must not become
+    // int64 50), tax IDs, or exact amounts you parse with a decimal type.
+    raw, err := insyra.ReadCSV_FileWithOptions("stocks.csv", insyra.CSVReadOptions{
+        FirstRowToColNames: true,
+        RawStrings:         true,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    _ = raw
+
     // Quick console preview (first N rows)
     insyra.Show("preview", dt, 5)
 }

--- a/skills/use-insyra-cli/SKILL.md
+++ b/skills/use-insyra-cli/SKILL.md
@@ -152,6 +152,7 @@ insyra --env exp1 run ./pipeline.isr
 insyra load matrix.csv headers false as t                  # no header row
 insyra load gdp.csv rownames true as t                     # first column = row names
 insyra load legacy.csv encoding big5 as t                  # CSV-only encoding hint
+insyra load stocks.csv infer false as raw                  # CSV-only: no type inference, all cells stay strings
 insyra load report.xlsx sheet 2025 rownames true as t      # Excel needs `sheet`
 insyra save report data.csv bom true                       # UTF-8 BOM (Windows Excel)
 insyra save gdp out.csv rownames true                      # row names as first col

--- a/skills/use-insyra-cli/references/cli-command-guide.md
+++ b/skills/use-insyra-cli/references/cli-command-guide.md
@@ -104,14 +104,15 @@ Generated from current command registry (`insyra help`, `insyra help <command>`)
 
 ### `load`
 - Description: Load data into a DataTable variable from a file, parquet, or SQL connection
-- Usage: `load <file> [headers true|false] [rownames true|false] [encoding <enc>] [sheet <name>] | load parquet <file> [cols <c1,c2,...>] [rowgroups <i1,i2,...>] | load sql <conn> <table> [where "..."] [order "..."] [limit N] [offset N] [cols "c1,c2"] [schema <s>] [indexcol <c>] [parsedates "c1,c2"] | load sql <conn> query "<SQL>" [params <v1> <v2> ...] [as <var>]`
-- Defaults: `headers=true`, `rownames=false`. Booleans accept `true|false|yes|no|on|off|1|0`.
-- Types: an all-integer CSV column loads as `int64` (large IDs keep full precision); a column with any decimal loads as `float64`; others stay strings.
+- Usage: `load <file> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [sheet <name>] | load parquet <file> [cols <c1,c2,...>] [rowgroups <i1,i2,...>] | load sql <conn> <table> [where "..."] [order "..."] [limit N] [offset N] [cols "c1,c2"] [schema <s>] [indexcol <c>] [parsedates "c1,c2"] | load sql <conn> query "<SQL>" [params <v1> <v2> ...] [as <var>]`
+- Defaults: `headers=true`, `rownames=false`, `infer=true`. Booleans accept `true|false|yes|no|on|off|1|0`.
+- Types: an all-integer CSV column loads as `int64` (large IDs keep full precision); a column with any decimal loads as `float64`; others stay strings. `infer false` (CSV only) skips this and keeps every cell as its original string — use it for stock IDs, tax IDs, or exact amounts where `0050` must not become `50`.
 - Examples:
   - `insyra load data.csv as t`
   - `insyra load matrix.csv headers false as t` (no header row)
   - `insyra load gdp.csv rownames true as t` (first column = row names)
   - `insyra load legacy.csv encoding big5 as t`
+  - `insyra load stocks.csv infer false as raw` (all cells stay raw strings)
   - `insyra load report.xlsx sheet 2025 rownames true as t`
   - `insyra load parquet data.parquet cols id,amount rowgroups 0,1 as t`
   - `insyra load sql main customers as customers`
@@ -119,7 +120,7 @@ Generated from current command registry (`insyra help`, `insyra help <command>`)
 
 ### `read`
 - Description: Quick preview a file without saving variable
-- Usage: `read <file> [headers true|false] [rownames true|false] [encoding <enc>] [sheet <name>]`
+- Usage: `read <file> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [sheet <name>]`
 - Example: `insyra read data.csv`
 - Note: forwards the same file options as `load`.
 

--- a/skills/use-insyra-cli/references/cli-command-usage.md
+++ b/skills/use-insyra-cli/references/cli-command-usage.md
@@ -300,11 +300,12 @@ This is separate from boolean-flag parsing used by option arguments like `header
 
 ## `load`
 - Description: Load data into a DataTable variable from a file, parquet, or SQL connection
-- Usage: `load <file> [headers true|false] [rownames true|false] [encoding <enc>] [sheet <name>] | load parquet <file> [cols <c1,c2,...>] [rowgroups <i1,i2,...>] | load sql <conn> <table> [where "..."] [order "..."] [limit N] [offset N] [cols "c1,c2"] [schema <s>] [indexcol <c>] [parsedates "c1,c2"] | load sql <conn> query "<SQL>" [params <v1> <v2> ...] [as <var>]`
+- Usage: `load <file> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [sheet <name>] | load parquet <file> [cols <c1,c2,...>] [rowgroups <i1,i2,...>] | load sql <conn> <table> [where "..."] [order "..."] [limit N] [offset N] [cols "c1,c2"] [schema <s>] [indexcol <c>] [parsedates "c1,c2"] | load sql <conn> query "<SQL>" [params <v1> <v2> ...] [as <var>]`
 - File options (CSV / Excel):
 	- `headers true|false` — first row is column names. Default `true`. JSON ignores this option (warns on use); Excel respects it.
 	- `rownames true|false` — first column is row names. Default `false`.
 	- `encoding <enc>` — CSV-only read-side hint (e.g. `big5`, `gbk`). Auto-detect when omitted.
+	- `infer true|false` — CSV-only. `infer false` keeps every cell as its original string (no type inference; empty cells stay `""`). Default `true`.
 	- `sheet <name>` — Excel-only; required for `.xlsx`/`.xlsm`/`.xls`.
 	- Booleans accept `true|false|yes|no|on|off|1|0` (case-insensitive).
 - SQL options:
@@ -410,7 +411,7 @@ This is separate from boolean-flag parsing used by option arguments like `header
 
 ## `read`
 - Description: Quick preview a file without saving variable
-- Usage: `read <file> [headers true|false] [rownames true|false] [encoding <enc>] [sheet <name>]`
+- Usage: `read <file> [headers true|false] [rownames true|false] [encoding <enc>] [infer true|false] [sheet <name>]`
 - Notes: forwards the file-side options to `load`; result is shown but not stored.
 
 ## `regression`


### PR DESCRIPTION
## What
Adds an options-based CSV loading API (`CSVReadOptions` + `ReadCSV_FileWithOptions` / `ReadCSV_StringWithOptions`) with a `RawStrings` mode that skips column type inference entirely — every cell stays its original string and empty cells stay `""`. Exposed through `isr` (`CSV_inOpts.RawStrings`) and the CLI (`load`/`read ... infer false`).

## Why
Closes #188 — column-level inference is destructive for "looks numeric but isn't" data: stock ID `0050` becomes `int64` `50` (leading zeros irreversibly lost), exact amounts are coerced to `float64`, and empty cells become `NaN`. Callers need a way to keep raw strings and parse with a decimal type themselves.

## How
- Legacy `ReadCSV_File` / `ReadCSV_String` keep their exact signatures and behavior, now thin wrappers over the options API; the duplicated File/String bodies are merged into a shared `csvRowsToDataTable`.
- `CSVReadOptions` zero value reproduces legacy behavior exactly (inference on), so the struct is safely extensible.
- CLI `infer true|false` (default `true`) is CSV-only; JSON/Excel reject it like `sheet`/`encoding`.
- Docs (`Docs/DataTable.md`, `Docs/cli-dsl.md`, `Docs/isr.md`) and skills (`skills/insyra`, `skills/use-insyra-cli`) updated in the same change; OpenSpec change `csv-raw-read-option` included (archive after merge).

## Testing
- `go test ./...` all green; `golangci-lint run` 0 issues; `go vet` clean.
- New tests: raw mode with the issue's exact sample (`0050`/`00878` leading zeros, `"2,000"` verbatim, empty → `""`), zero-value-options ≡ legacy output, isr pass-through, CLI `infer false`, JSON/Excel rejection.
- Manual: `insyra read stocks.csv infer false` shows all three columns as raw strings.

## Checklist
- [x] Tests pass
- [x] No secrets committed
- [x] Migrations reversible (n/a)
- [x] Docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)