### PR TITLE
docs(ml,nn): package pages carry the standard heading and current descriptions

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -63,8 +63,8 @@ dt.Show()
 | Document          | Description                                             |
 | ----------------- | ------------------------------------------------------- |
 | [stats](stats.md) | Correlation, hypothesis testing, regression, ANOVA, PCA, clustering |
-| [ml](ml.md)       | Common estimator and transformer protocol over `stats` models |
-| [dl](nn.md)       | Pure-Go float32 ONNX inference for focused MLP graphs |
+| [ml](ml.md)       | scikit-learn-style modeling: regressions, trees, forests, boosting, pipelines, cross-validation and grid search, with ONNX export |
+| [nn](nn.md)       | Pure-Go neural networks: ONNX inference and training, layers and autodiff, SafeTensors I/O, GPU-accelerated MatMul |
 
 #### Visualization
 

--- a/Docs/ml.md
+++ b/Docs/ml.md
@@ -1,6 +1,6 @@
-# `ml` Package
+# [ ml ] Package
 
-The `ml` package provides one estimator protocol over the classical models already implemented by `stats`. It wraps fitted results without reimplementing the statistical algorithms.
+The `ml` package provides scikit-learn-style modeling under one estimator protocol. The classical regression families wrap the models already implemented by `stats`; decision trees, random forests, and gradient boosting are implemented here as deterministic histogram trees. Splitting and cross-validation, grid search, metrics, pipelines, and ONNX export complete the workflow.
 
 ## Installation
 

--- a/Docs/nn.md
+++ b/Docs/nn.md
@@ -1,10 +1,16 @@
-# `nn` Package
+# [ nn ] Package
 
-The `nn` package loads a focused subset of ONNX models and runs them with pure
-Go. It is intended for small inference graphs such as exported multilayer
-perceptrons, transformer encoder blocks, and MNIST-class CNN classifiers. The
-graph is validated when it is loaded, and runtime inputs and outputs are bound
-by name.
+The `nn` package is a neural network engine in pure Go, with zero non-Go
+dependencies. It loads and runs a focused subset of ONNX models — up to real
+published checkpoints such as MobileNetV2, MiniLM, and tiny-YOLOv3, each
+verified against `onnxruntime` — and it trains networks through a
+reverse-mode tape and a `Sequential` layer API, with gradients verified
+against PyTorch and finite differences.
+
+Weights load and save as SafeTensors, and trained models export back to ONNX.
+The largest matrix products run on a GPU when one is present and fall back to
+a bit-identical CPU path when none is. The graph is validated when it is
+loaded, and runtime inputs and outputs are bound by name.
 
 ## Installation
 


### PR DESCRIPTION
## What
Aligns the nn and ml doc pages with the docs conventions: the H1 now uses the bracketed `[ pkg ] Package` form every other package page uses (and which the generated sidebar copies verbatim), and both page intros plus the docs-index rows now describe the packages as they are — nn trains as well as infers, ml implements trees and ensembles natively.

## Why
The two pages shipped with a backtick-style H1 that leaked into the docsify sidebar, and their descriptions predated nn's training support and ml's native tree/ensemble implementations. The docs index also still labeled nn with its `dl` branch-era name.

## How
Docs-only: three files under `Docs/`. Every claim in the rewritten intros maps to an existing section of the same page.

## Testing
- `go test ./...`: 31 packages, all pass
- Docs-only change; no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)