### PR TITLE
fix(stats): orthogonal FA rotations stay orthogonal when Restarts > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ v0.3.0 and everything before it is not repeated here — see [GitHub Releases](h
 
 ## Unreleased
 
+### `stats`
+
+- Fixed orthogonal factor rotations (Varimax / Quartimax / GeominT / BentlerT) returning a non-orthogonal rotation matrix when `Rotation.Restarts > 1`. Restarts now only uses orthonormal starts for those methods and caps the total start count. ([issue #373](https://github.com/HazelnutParadise/insyra/issues/373))
+
 ## v0.3.2
 
 ### Core

--- a/CHANGELOG_TW.md
+++ b/CHANGELOG_TW.md
@@ -8,6 +8,10 @@ English: [CHANGELOG.md](CHANGELOG.md)
 
 ## Unreleased
 
+### `stats`
+
+- 修正正交因子旋轉（Varimax／Quartimax／GeominT／BentlerT）在 `Rotation.Restarts > 1` 時回傳非正交旋轉矩陣的問題。這些方法的 Restarts 現在只用正交起點，並限制起點總數。（[issue #373](https://github.com/HazelnutParadise/insyra/issues/373)）
+
 ## v0.3.2
 
 ### Core

--- a/Docs/stats.md
+++ b/Docs/stats.md
@@ -1245,7 +1245,8 @@ const (
 The model matrix is preserved across rotations:
 `L_rotated · Phi · L_rotated' = L_unrotated · L_unrotated'`. For orthogonal
 rotations Phi = I and the relationship simplifies to `L · L' = Lu · Lu'`.
-This invariant is checked by `TestRotationInvariants`.
+This invariant is checked by `TestRotationInvariants`. Orthogonal methods with
+`Restarts > 1` only try orthonormal starts so that property still holds.
 
 #### Factor Score Method
 
@@ -1301,7 +1302,7 @@ type FactorRotationOptions struct {
     Kappa            float64          // Promax power m (default 4); cast to int internally
     Delta            float64          // Oblimin gamma (default 0)
     GeominEpsilon    float64          // Geomin ε (default 0.01)
-    Restarts         int              // random orthonormal starts for GPA rotations (default 1)
+    Restarts         int              // GPA starts (default 1). Orthogonal methods use only orthonormal starts (identity / Varimax / random); oblique methods may also use Promax / Target. Caps total starts, not only random ones.
     VarimaxAlgorithm VarimaxAlgorithm // "kaiser" (psych default) or "gparotation"
 }
 ```

--- a/openspec/changes/2026-09-12-fix-fa-orthogonal-restarts/proposal.md
+++ b/openspec/changes/2026-09-12-fix-fa-orthogonal-restarts/proposal.md
@@ -1,0 +1,21 @@
+# Change: Keep orthogonal FA rotations orthogonal when Restarts > 1
+
+## Why
+
+`FactorAnalysis` orthogonal rotations (Varimax / Quartimax / GeominT / BentlerT) with `Rotation.Restarts > 1` can return a non-orthogonal rotation matrix. Communalities then change under a supposed orthogonal rotation, so the rotated loadings no longer represent the same model as the unrotated ones. Default `Restarts: 1` is fine; raising Restarts (documented as searching for a better local minimum) triggers the bug without error or warning.
+
+Root cause: `FaRotations` adds Promax and TargetRot start matrices whenever `restarts > 1`. Those starts are oblique. GPA preserves orthogonality relative to the start, so a non-orthogonal start yields a non-orthogonal `rotmat`. When that start wins on the criterion, the caller gets a broken "orthogonal" solution. Heuristic starts also ignore the Restarts budget.
+
+## What Changes
+
+- For orthogonal methods, only identity, Varimax, and random orthonormal starts are used; Promax / TargetRot starts are reserved for oblique methods.
+- `Restarts` caps the total number of starts (heuristics + random), not only the random ones.
+- Orthogonal starts are QR-orthonormalized before use.
+- Tests pin `R'R ≈ I` and stable communalities for orthogonal methods with Restarts > 1.
+- Docs and both changelogs note the corrected Restarts behaviour.
+
+## Impact
+
+- Affected code: `stats/internal/fa/psych_faRotations.go`
+- User-visible: orthogonal rotation numeric output when `Restarts > 1` (values that were wrong become correct)
+- No API break; default Restarts path unchanged

--- a/openspec/changes/2026-09-12-fix-fa-orthogonal-restarts/specs/stats-factor-rotation/spec.md
+++ b/openspec/changes/2026-09-12-fix-fa-orthogonal-restarts/specs/stats-factor-rotation/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Orthogonal rotations keep an orthogonal rotation matrix under restarts
+
+When the caller requests an orthogonal factor rotation (Varimax, Quartimax, GeominT, BentlerT), the system SHALL return a rotation matrix R satisfying R'R ≈ I, including when `Rotation.Restarts` is greater than 1.
+
+Orthogonal methods SHALL NOT use oblique heuristic starts (Promax, TargetRot). Starts for orthogonal methods SHALL be orthonormal (identity, Varimax, or random orthonormal), and `Restarts` SHALL bound the total number of starts.
+
+#### Scenario: Quartimax with Restarts greater than 1
+
+- **WHEN** FactorAnalysis (or FaRotations) runs Quartimax with Restarts ≥ 2 on a multi-factor loading matrix
+- **THEN** the returned rotation matrix satisfies max|R'R − I| at machine precision
+- **AND** per-variable communalities match the unrotated loadings (max |h²_rotated − h²_unrotated| at machine precision)
+
+#### Scenario: Restarts equals 1 stays identity-only
+
+- **WHEN** Restarts is 1 (the FactorAnalysis default)
+- **THEN** only the identity start is used
+- **AND** orthogonal methods still return an orthogonal R
+
+#### Scenario: Oblique methods may still use Promax / Target starts
+
+- **WHEN** an oblique rotation supporting restarts runs with Restarts > 1
+- **THEN** Promax and TargetRot heuristic starts remain allowed within the Restarts budget

--- a/openspec/changes/2026-09-12-fix-fa-orthogonal-restarts/tasks.md
+++ b/openspec/changes/2026-09-12-fix-fa-orthogonal-restarts/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+## 1. Fix start selection
+- [x] 1.1 Skip Promax / TargetRot starts for orthogonal methods (varimax, quartimax, geomint, bentlert)
+- [x] 1.2 Cap total starts at `Restarts` (heuristics + random)
+- [x] 1.3 QR-orthonormalize starts for orthogonal methods
+
+## 2. Tests
+- [x] 2.1 Add package test that fails before the fix for Quartimax/Varimax/GeominT/BentlerT with Restarts > 1
+- [x] 2.2 Confirm communalities stay stable and `R'R ≈ I`
+
+## 3. Docs
+- [x] 3.1 Clarify Restarts start rules in `Docs/stats.md`
+- [x] 3.2 Add Unreleased entries to `CHANGELOG.md` and `CHANGELOG_TW.md`

--- a/stats/internal/fa/fa_restarts_orthogonality_test.go
+++ b/stats/internal/fa/fa_restarts_orthogonality_test.go
@@ -1,0 +1,83 @@
+package fa
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func maxAbsRTRI(R *mat.Dense) float64 {
+	n, _ := R.Dims()
+	RT := mat.DenseCopyOf(R.T())
+	var RTR mat.Dense
+	RTR.Mul(RT, R)
+	maxd := 0.0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			want := 0.0
+			if i == j {
+				want = 1
+			}
+			if d := math.Abs(RTR.At(i, j) - want); d > maxd {
+				maxd = d
+			}
+		}
+	}
+	return maxd
+}
+
+func maxCommunalityChange(Lu, L *mat.Dense) float64 {
+	p, k := Lu.Dims()
+	maxd := 0.0
+	for i := 0; i < p; i++ {
+		hu, h := 0.0, 0.0
+		for j := 0; j < k; j++ {
+			hu += Lu.At(i, j) * Lu.At(i, j)
+			h += L.At(i, j) * L.At(i, j)
+		}
+		if d := math.Abs(h - hu); d > maxd {
+			maxd = d
+		}
+	}
+	return maxd
+}
+
+// blockyLoadings builds a 6×3 loading pattern similar to issue #373's synthetic case.
+func blockyLoadings(seed int64) *mat.Dense {
+	rnd := rand.New(rand.NewSource(seed))
+	L := mat.NewDense(6, 3, nil)
+	for i := 0; i < 6; i++ {
+		for j := 0; j < 3; j++ {
+			v := 0.1 * rnd.NormFloat64()
+			if i/2 == j {
+				v += 0.7
+			}
+			L.Set(i, j, v)
+		}
+	}
+	return L
+}
+
+func TestFaRotations_OrthogonalRestartsKeepOrthogonality(t *testing.T) {
+	L := blockyLoadings(42)
+	for _, method := range []string{"quartimax", "varimax", "geomint", "bentlert"} {
+		for _, restarts := range []int{1, 2, 5, 20} {
+			rotL, R, _, _, err := Rotate(L, method, &RotOpts{Restarts: restarts, Eps: 1e-5, MaxIter: 1000})
+			if err != nil {
+				t.Errorf("[%s restarts=%d] %v", method, restarts, err)
+				continue
+			}
+			orth := maxAbsRTRI(R)
+			h2 := maxCommunalityChange(L, rotL)
+			t.Logf("[%s restarts=%d] max|R'R-I|=%.3e max|h2Δ|=%.3e", method, restarts, orth, h2)
+			if orth > 1e-8 {
+				t.Errorf("[%s restarts=%d] rotmat not orthogonal: max|R'R-I|=%.3e", method, restarts, orth)
+			}
+			if h2 > 1e-8 {
+				t.Errorf("[%s restarts=%d] communalities changed under orthogonal rotation: max|h2Δ|=%.3e", method, restarts, h2)
+			}
+		}
+	}
+}

--- a/stats/internal/fa/psych_faRotations.go
+++ b/stats/internal/fa/psych_faRotations.go
@@ -472,37 +472,55 @@ func FaRotations(loadings *mat.Dense, r *mat.Dense, rotate string, hyper float64
 		baseLoadings = loadings
 	}
 
-	// Build starting rotation matrices
-	// To emulate SPSS Direct Oblimin behavior deterministically, when
-	// restarts <= 1, use only identity start. For larger restarts, include
-	// additional heuristics (Varimax/Promax/Target) and random starts up to
-	// the requested count.
+	// Orthogonal GPA methods preserve R'R = I only when every start is orthogonal.
+	// Promax / TargetRot starts are oblique; if they win on the criterion they
+	// silently return a non-orthogonal "orthogonal" rotation (issue #373).
+	// Oblique methods may still use those heuristics. Restarts is a hard cap on
+	// the total number of starts (heuristics + random), not only the random ones.
+	orthogonalMethods := map[string]bool{
+		"varimax":   true,
+		"quartimax": true,
+		"geomint":   true,
+		"bentlert":  true,
+	}
+	isOrthogonal := orthogonalMethods[rotateLower]
+
 	starts := make([]*mat.Dense, 0, max(1, restarts))
 	starts = append(starts, identityMatrix(nf))
 	if restarts > 1 && nf > 1 {
-		// Heuristic starts
-		vm := Varimax(baseLoadings, true, 1e-08, 5000)
-		if rot, ok := vm["rotmat"].(*mat.Dense); ok && rot != nil {
-			starts = append(starts, mat.DenseCopyOf(rot))
+		if len(starts) < restarts {
+			vm := Varimax(baseLoadings, true, 1e-08, 5000)
+			if rot, ok := vm["rotmat"].(*mat.Dense); ok && rot != nil {
+				starts = append(starts, mat.DenseCopyOf(rot))
+			}
 		}
-		pm := Promax(baseLoadings, 4, true)
-		if rot, ok := pm["rotmat"].(*mat.Dense); ok && rot != nil {
-			starts = append(starts, mat.DenseCopyOf(rot))
-		}
-		if loadings != nil {
-			if _, trgRot, _, err := TargetRot(baseLoadings); err == nil {
-				if trgRot != nil {
+		if !isOrthogonal {
+			if len(starts) < restarts {
+				pm := Promax(baseLoadings, 4, true)
+				if rot, ok := pm["rotmat"].(*mat.Dense); ok && rot != nil {
+					starts = append(starts, mat.DenseCopyOf(rot))
+				}
+			}
+			if len(starts) < restarts && loadings != nil {
+				if _, trgRot, _, err := TargetRot(baseLoadings); err == nil && trgRot != nil {
 					starts = append(starts, mat.DenseCopyOf(trgRot))
 				}
 			}
 		}
-		// Add random orthonormal starts if budget remains
-		if restarts > len(starts) {
+		if len(starts) < restarts {
 			seed := seedFromMatrix(baseLoadings)
 			rnd := rand.New(rand.NewSource(seed))
-			for i := len(starts); i < restarts; i++ {
+			for len(starts) < restarts {
 				starts = append(starts, randomOrthonormalMatrix(nf, rnd))
 			}
+		}
+	}
+
+	// QR-orthonormalize starts for orthogonal methods so a drifted heuristic
+	// cannot leave the Stiefel manifold (R GPArotation::Random.Start does this).
+	if isOrthogonal {
+		for i, s := range starts {
+			starts[i] = orthonormalizeColumns(s)
 		}
 	}
 
@@ -690,6 +708,33 @@ func randomOrthonormalMatrix(n int, rnd *rand.Rand) *mat.Dense {
 	var q mat.Dense
 	qr.QTo(&q)
 	return mat.DenseCopyOf(&q)
+}
+
+
+// orthonormalizeColumns returns the Q factor of A via thin QR so columns are
+// orthonormal. Keeps orthogonal-rotation starts on the Stiefel manifold.
+func orthonormalizeColumns(A *mat.Dense) *mat.Dense {
+	if A == nil {
+		return nil
+	}
+	r, c := A.Dims()
+	if r == 0 || c == 0 {
+		return mat.DenseCopyOf(A)
+	}
+	var qr mat.QR
+	qr.Factorize(A)
+	var q mat.Dense
+	qr.QTo(&q)
+	if q.RawMatrix().Cols == c {
+		return mat.DenseCopyOf(&q)
+	}
+	out := mat.NewDense(r, c, nil)
+	for j := 0; j < c; j++ {
+		for i := 0; i < r; i++ {
+			out.Set(i, j, q.At(i, j))
+		}
+	}
+	return out
 }
 
 func seedFromMatrix(m *mat.Dense) int64 {


### PR DESCRIPTION
Fixes #373.

Orthogonal methods (Varimax / Quartimax / GeominT / BentlerT) were seeding Restarts with Promax and TargetRot starts. Those are oblique, so when one won on the criterion you got a non-orthogonal R and communalities drifted.

Orthogonal methods now only use orthonormal starts (identity, Varimax, random), Restarts caps the total start count, and starts are QR-orthonormalized. Test covers Restarts 1/2/5/20 for the four orthogonal methods.